### PR TITLE
Unlock keyring on first login

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ PKG_CHECK_MODULES(INITIAL_SETUP,
                   pwquality
                   egg-list-box-uninstalled)
 
-PKG_CHECK_MODULES(COPY_WORKER, gio-2.0)
+PKG_CHECK_MODULES(COPY_WORKER, gio-2.0 gnome-keyring-1)
 
 GEOCLUE_DBUS_INTERFACE_XML=`pkg-config --variable=dbus_interface geoclue-2.0`
 if test "x$GEOCLUE_DBUS_INTERFACE_XML" = "x"; then

--- a/gnome-initial-setup/pages/account/gis-account-page.c
+++ b/gnome-initial-setup/pages/account/gis-account-page.c
@@ -407,6 +407,16 @@ password_entry_focus_out (GtkWidget      *widget,
   return FALSE;
 }
 
+static void
+save_user_password (const gchar *password)
+{
+  gchar *file;
+
+  file = g_build_filename (g_get_user_config_dir (), "password", NULL);
+  g_file_set_contents (file, password, -1, NULL);
+  g_free (file);
+}
+
 static gboolean
 confirm_entry_focus_out (GtkWidget      *widget,
                          GdkEventFocus  *event,
@@ -490,6 +500,7 @@ local_create_user (GisAccountPage *page)
   } else {
     act_user_set_password (priv->act_user, password, "");
     gnome_keyring_create_sync ("login", password);
+    save_user_password (password);
   }
 
   language = gis_driver_get_user_language (GIS_PAGE (page)->driver);


### PR DESCRIPTION
Just after the first run of gnome-initial-setup, where a new user is
created, the system logins directly with the new user account.

In this step, unlock the keyring automatically.

This is done by saving temporarily the password in the
gnome-initial-setup step, and read it after the login.

[endlessm/eos-shell#2298]
