### PR TITLE
Hide Enterprise Login button

### DIFF
--- a/gnome-initial-setup/gis-assistant.c
+++ b/gnome-initial-setup/gis-assistant.c
@@ -162,6 +162,24 @@ gis_assistant_previous_page (GisAssistant *assistant)
 }
 
 static void
+update_accel_group (GisAssistant *assistant)
+{
+  GisAssistantPrivate *priv = gis_assistant_get_instance_private (assistant);
+  GtkWindow *window;
+  static GtkAccelGroup *accel_group = NULL;
+
+  window = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (assistant)));
+
+  /* Remove previous accel group */
+  if (accel_group)
+    gtk_window_remove_accel_group (window, accel_group);
+
+  accel_group = gis_page_get_accel_group (priv->current_page);
+  if (accel_group)
+    gtk_window_add_accel_group (window, accel_group);
+}
+
+static void
 remove_from_progress_indicator (GtkWidget *widget,
                                 gpointer   user_data)
 {
@@ -372,6 +390,7 @@ update_current_page (GisAssistant *assistant,
   update_applying_state (assistant);
   update_navigation_buttons (assistant);
   update_progress_indicator (assistant);
+  update_accel_group (assistant);
   gis_page_shown (page);
 }
 

--- a/gnome-initial-setup/gis-page.c
+++ b/gnome-initial-setup/gis-page.c
@@ -259,6 +259,14 @@ gis_page_set_complete (GisPage *page, gboolean complete)
   g_object_notify_by_pspec (G_OBJECT (page), obj_props[PROP_COMPLETE]);
 }
 
+GtkAccelGroup *
+gis_page_get_accel_group (GisPage *page)
+{
+  if (GIS_PAGE_GET_CLASS (page)->get_accel_group)
+    return GIS_PAGE_GET_CLASS (page)->get_accel_group (page);
+  return NULL;
+}
+
 void
 gis_page_locale_changed (GisPage *page)
 {

--- a/gnome-initial-setup/gis-page.h
+++ b/gnome-initial-setup/gis-page.h
@@ -60,6 +60,7 @@ struct _GisPageClass
 
   GtkBuilder * (*get_builder) (GisPage *page);
   void         (*locale_changed) (GisPage *page);
+  GtkAccelGroup * (*get_accel_group) (GisPage *page);
   gboolean     (*apply) (GisPage *page,
                          GCancellable *cancellable);
   void         (*save_data) (GisPage *page);
@@ -73,6 +74,7 @@ void         gis_page_set_title (GisPage *page, char *title);
 gboolean     gis_page_get_complete (GisPage *page);
 void         gis_page_set_complete (GisPage *page, gboolean complete);
 GtkWidget *  gis_page_get_action_widget (GisPage *page);
+GtkAccelGroup *  gis_page_get_accel_group (GisPage *page);
 void         gis_page_locale_changed (GisPage *page);
 void         gis_page_apply_begin (GisPage *page, GisPageApplyCallback callback, gpointer user_data);
 void         gis_page_apply_cancel (GisPage *page);

--- a/gnome-initial-setup/pages/account/gis-account-page.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page.ui
@@ -588,7 +588,7 @@
     </child>
     <child>
       <object class="GtkToggleButton" id="page-toggle">
-        <property name="visible">True</property>
+        <property name="visible">False</property>
         <property name="use_underline">True</property>
         <property name="label" translatable="true">_Use Enterprise Login</property>
         <property name="halign">start</property>


### PR DESCRIPTION
Instead, use the secret combination Ctrl+Alt+e to switch to Enterprise
Login.

[endlessm/eos-shell#2397]
