### PR TITLE
Add shared library dependencies to binary package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Homepage: https://git.gnome.org/browse/gnome-initial-setup/
 
 Package: gnome-initial-setup
 Architecture: any
-Depends: ${misc:Depends},
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
          gdm3,
 	 policykit-1 (>= 0.106)
 Recommends: gnome-getting-started-docs


### PR DESCRIPTION
This ensures that all library dependencies (including libzint) are
pulled in on install.

[endlessm/eos-shell#2437]
