### PR TITLE
Allow initial setup to switch metrics on and off

### DIFF
--- a/data/20-gnome-initial-setup.rules
+++ b/data/20-gnome-initial-setup.rules
@@ -10,6 +10,7 @@ polkit.addRule(function(action, subject) {
         return undefined;
 
     var actionMatches = (action.id === 'org.freedesktop.udisks2.filesystem-mount-system' ||
+                         action.id === 'com.endlessm.Metrics.SetEnabled' ||
                          action.id.indexOf('org.freedesktop.hostname1.') === 0 ||
                          action.id.indexOf('org.freedesktop.NetworkManager.') === 0 ||
                          action.id.indexOf('org.freedesktop.locale1.') === 0 ||


### PR DESCRIPTION
Change the polkit permissions rules to allow this. Only allow
access to the `SetEnabled` method, which is currently the only
method that is protected.
[endlessm/eos-sdk#1327]
