### PR TITLE
product_serial: make it world-readable

### DIFF
--- a/data/product_serial.conf
+++ b/data/product_serial.conf
@@ -1,1 +1,1 @@
-z    /sys/devices/virtual/dmi/id/product_uuid 0440 root nogroup - -
+z    /sys/devices/virtual/dmi/id/product_uuid 0444 root nogroup - -


### PR DESCRIPTION
Use mode 444 so that e.g. eos-diagnostic can also read it.

[endlessm/eos-shell#2203]
