### PR TITLE
account-page: limit full name to 80 chars

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page.ui
@@ -62,7 +62,7 @@
             </child>
             <child>
               <object class="GtkEntry" id="account-fullname-entry">
-                <property name="max_length">255</property>
+                <property name="max_length">80</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="invisible_char">●</property>


### PR DESCRIPTION
Debian/Ubuntu ship a patch to accountsservice that makes it use adduser
instead of the default useradd when adding an user to the system.
One of the differences between adduser and useradd is that the former
calls into chfn to set the user full name. That has a limitation of 80
characters, and user creation will then fail when a longer full name is
provided.

Instead of reverting the accountsservice patch (which might have
unforeseen consequences) at this point the safest thing to do is to
limit the number of characters that can be entered in the FBE to match
the limit of chfn - i.e. 80 characters.

[endlessm/eos-shell#2903]
