### PR TITLE
location: use DesktopId when making requests to Geoclue

### DIFF
--- a/gnome-initial-setup/pages/location/cc-timezone-monitor.c
+++ b/gnome-initial-setup/pages/location/cc-timezone-monitor.c
@@ -302,7 +302,7 @@ on_client_proxy_ready (GObject      *source_object,
 
         priv = GET_PRIVATE (self);
         priv->geoclue_client = client;
-        //geoclue_client_set_desktop_id (priv->geoclue_client, DESKTOP_ID);
+        geoclue_client_set_desktop_id (priv->geoclue_client, DESKTOP_ID);
         geoclue_client_set_distance_threshold (priv->geoclue_client,
                                                GEOCODE_LOCATION_ACCURACY_CITY);
         //geoclue_client_set_requested_accuracy_level (priv->geoclue_client,


### PR DESCRIPTION
Geoclue recently started mandating a desktop ID whitelist for
applications allowed to use geolocation. Set it in code, so that we can
retrieve the timezone automatically.

[endlessm/eos-shell#3022]
