### PR TITLE
keyboard: disconnect from settings notification when finalizing

### DIFF
--- a/gnome-initial-setup/pages/keyboard/gis-keyboard-page.c
+++ b/gnome-initial-setup/pages/keyboard/gis-keyboard-page.c
@@ -99,9 +99,11 @@ gis_keyboard_page_finalize (GObject *object)
         g_cancellable_cancel (priv->cancellable);
         g_clear_object (&priv->cancellable);
 
+        g_signal_handlers_disconnect_by_data (priv->input_settings, self);
+        g_clear_object (&priv->input_settings);
+
         g_clear_object (&priv->permission);
         g_clear_object (&priv->localed);
-        g_clear_object (&priv->input_settings);
         g_clear_object (&priv->xkb_info);
 #ifdef HAVE_IBUS
         g_clear_object (&priv->ibus);


### PR DESCRIPTION
Due to the use of g_settings_delay() in the keyboard page, it's
possible for the backend object to survive the page itself, when the
locale changes.
In that scenario, a callback will be triggered with an invalid page
pointer, which will eventually lead to a crash.

Disconnect all handlers connected by the page when finalizing it.

[endlessm/eos-shell#2904]
