### PR TITLE
Change automatic login switch to checkbutton

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page.c
+++ b/gnome-initial-setup/pages/account/gis-account-page.c
@@ -480,7 +480,8 @@ local_create_user (GisAccountPage *page)
   username = gtk_combo_box_text_get_active_text (OBJ(GtkComboBoxText*, "account-username-combo"));
   fullname = gtk_entry_get_text (OBJ (GtkEntry*, "account-fullname-entry"));
   password = gtk_entry_get_text (OBJ (GtkEntry*, "account-password-entry"));
-  autologin_active = gtk_switch_get_active (OBJ(GtkSwitch*, "account-autologin-switch"));
+  autologin_active = gtk_toggle_button_get_active (OBJ (GtkToggleButton*,
+                                                   "account-autologin-button"));
 
   priv->act_user = act_user_manager_create_user (priv->act_client, username, fullname, priv->account_type, &error);
   if (error != NULL) {

--- a/gnome-initial-setup/pages/account/gis-account-page.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page.ui
@@ -309,40 +309,11 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="account-autologin-label">
+              <object class="GtkCheckButton" id="account-autologin-button">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="xalign">1</property>
+                <property name="can_focus">True</property>
                 <property name="label" translatable="yes">A_utomatic Login</property>
                 <property name="use_underline">True</property>
-                <property name="mnemonic_widget">account-autologin-switch</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">9</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="box3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkSwitch" id="account-autologin-switch">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>


### PR DESCRIPTION
The "automatic login" option on the accounts page is now a
GtkCheckButton instead of a GtkSwitch. A GtkCheckButton includes its
own label, so the original label was removed (but the string is
identical, so no translation changes needed.)

While doing so, removed a redundant GtkBox around the checkbutton.

[endlessm/eos-shell#3274]
