### PR TITLE
Add "Skip WiFi setup" checkbox

### DIFF
--- a/gnome-initial-setup/pages/network/gis-network-page.ui
+++ b/gnome-initial-setup/pages/network/gis-network-page.ui
@@ -140,7 +140,22 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
+        <property name="top_attach">4</property>
+        <property name="width">1</property>
+        <property name="height">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="skip-network-button">
+        <property name="visible">True</property>
+        <property name="label" translatable="yes">_Skip WiFi setup</property>
+        <property name="use_underline">True</property>
+        <property name="halign">start</property>
+        <property name="valign">center</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">5</property>
         <property name="width">1</property>
         <property name="height">1</property>
       </packing>


### PR DESCRIPTION
In order to prevent users from accidentally moving past the page where
they can configure their wireless network, we make the "Next" button
insensitive. It becomes sensitive again when the user has either set up
their network (i.e. NetworkManager's global state is CONNECTED_GLOBAL)
or checked a checkbox that says "Skip WiFi setup".

[endlessm/eos-shell#3273]
