### PR TITLE
set the envvar LC_MESSAGES

### DIFF
--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -131,6 +131,9 @@ set_language (GisLanguagePage *page)
   setlocale (LC_MESSAGES, priv->new_locale_id);
   gis_driver_locale_changed (driver);
 
+  /* gis spawns processes that also need to be localised */
+  g_setenv ("LC_MESSAGES", priv->new_locale_id, TRUE);
+
   if (gis_driver_get_mode (driver) == GIS_DRIVER_MODE_NEW_USER) {
       if (g_permission_get_allowed (priv->permission)) {
           set_localed_locale (page);


### PR DESCRIPTION
When the user sets their preferred language, the environment variable
LC_MESSAGES shall be set too, because gis might spawns processes (e.g.
gkbd-keyboard-display) and they should be localised accordingly.

[endlessm/eos-shell#3172]
