### PR TITLE
add ar.SY in the languages list

### DIFF
--- a/gnome-initial-setup/pages/language/cc-common-language.c
+++ b/gnome-initial-setup/pages/language/cc-common-language.c
@@ -304,6 +304,7 @@ cc_common_language_get_initial_languages (void)
         insert_language (ht, "es_GT");
         insert_language (ht, "es_MX");
         insert_language (ht, "pt_BR");
+        insert_language (ht, "ar_SY");
 
         insert_user_languages (ht);
 


### PR DESCRIPTION
As when reading the personality file the prefered language is set,
there is no need to add more logic on it.

[endlessm/eos-shell#3351]
