### PR TITLE
Only show en_US and user languages (if any) in the initial page

### DIFF
--- a/gnome-initial-setup/pages/language/cc-common-language.c
+++ b/gnome-initial-setup/pages/language/cc-common-language.c
@@ -301,11 +301,6 @@ cc_common_language_get_initial_languages (void)
         ht = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
         insert_language (ht, "en_US");
-        insert_language (ht, "es_GT");
-        insert_language (ht, "es_MX");
-        insert_language (ht, "pt_BR");
-        insert_language (ht, "ar_SY");
-
         insert_user_languages (ht);
 
         return ht;


### PR DESCRIPTION
This way, during the FBE the Global image should show only the en_US
language, while other images with personality would add whatever the
default language is defined in /etc/EndlessOS/personality.conf.

Note that more options will be shown if there are other users in the
system with aditional languages installed, but that should not affect
the FBE anyway.

[endlessm/eos-shell#3507]
