### PR TITLE
gnome-initial-setup: disable the GOA page

### DIFF
--- a/gnome-initial-setup/gnome-initial-setup.c
+++ b/gnome-initial-setup/gnome-initial-setup.c
@@ -79,7 +79,6 @@ static PageData page_table[] = {
   PAGE (network),
   PAGE (account),
   PAGE (location),
-  PAGE (goa),
   PAGE (summary),
   { NULL },
 };


### PR DESCRIPTION
We're going to disable this for now.

[endlessm/eos-shell#3717]
