### PR TITLE
copy-worker: don't forget to copy over monitors.xml

### DIFF
--- a/gnome-initial-setup/gnome-initial-setup-copy-worker.c
+++ b/gnome-initial-setup/gnome-initial-setup-copy-worker.c
@@ -112,6 +112,7 @@ main (int    argc,
   FILE (".config/run-welcome-tour");
   FILE (".config/dconf/user");
   FILE (".config/goa-1.0/accounts.conf");
+  FILE (".config/monitors.xml");
   FILE (".local/share/keyrings/login.keyring");
 
   unlock_keyring (initial_setup_homedir);


### PR DESCRIPTION
Or we will not propagate the overscan configuration to the session.

[endlessm/eos-shell#3704]
