### PR TITLE
network: remove spinner when searching for networks

### DIFF
--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -355,12 +355,10 @@ refresh_without_device (GisNetworkPage *page)
 {
   GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
   GtkWidget *label;
-  GtkWidget *spinner;
   GtkWidget *swin;
 
   swin = WID("network-scrolledwindow");
   label = WID("no-network-label");
-  spinner = WID("no-network-spinner");
 
   if (nm_client_get_state (priv->nm_client) == NM_STATE_CONNECTED_GLOBAL)
     ;
@@ -370,7 +368,6 @@ refresh_without_device (GisNetworkPage *page)
     gtk_label_set_text (GTK_LABEL (label), _("No network devices found."));
 
   gtk_widget_hide (swin);
-  gtk_widget_hide (spinner);
   gtk_widget_show (label);
 }
 
@@ -386,7 +383,6 @@ refresh_wireless_list (GisNetworkPage *page)
   gboolean disable_skip = FALSE;
   guint i;
   GtkWidget *label;
-  GtkWidget *spinner;
   GtkWidget *swin;
   GList *children, *l;
   GtkWidget *list;
@@ -427,7 +423,6 @@ refresh_wireless_list (GisNetworkPage *page)
 
   swin = WID("network-scrolledwindow");
   label = WID("no-network-label");
-  spinner = WID("no-network-spinner");
 
   if (state == NM_DEVICE_STATE_UNMANAGED ||
       state == NM_DEVICE_STATE_UNAVAILABLE) {
@@ -437,7 +432,6 @@ refresh_wireless_list (GisNetworkPage *page)
   else if (aps == NULL || aps->len == 0) {
     gtk_label_set_text (GTK_LABEL (label), _("Checking for available wireless networks"));
     gtk_widget_hide (swin);
-    gtk_widget_show (spinner);
     gtk_widget_show (label);
     g_timeout_add_seconds (1, refresh_again, page);
 
@@ -445,7 +439,6 @@ refresh_wireless_list (GisNetworkPage *page)
   }
   else {
     gtk_widget_show (swin);
-    gtk_widget_hide (spinner);
     gtk_widget_hide (label);
   }
 

--- a/gnome-initial-setup/pages/network/gis-network-page.ui
+++ b/gnome-initial-setup/pages/network/gis-network-page.ui
@@ -108,22 +108,6 @@
         <property name="halign">start</property>
         <property name="valign">start</property>
         <child>
-          <object class="GtkSpinner" id="no-network-spinner">
-            <property name="visible">True</property>
-            <property name="active">True</property>
-            <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="margin-left">6</property>
-            <property name="margin-right">6</property>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel" id="no-network-label">
             <property name="visible">True</property>
             <property name="label" translatable="yes">No wireless available</property>
@@ -131,7 +115,7 @@
             <property name="valign">center</property>
           </object>
           <packing>
-            <property name="left_attach">1</property>
+            <property name="left_attach">0</property>
             <property name="top_attach">0</property>
             <property name="width">1</property>
             <property name="height">1</property>


### PR DESCRIPTION
People find it confusing to have a spinner there, as it communicates
that they have to wait. While we wait for a proper redesign of the
network page, let's just remove it for now.

[endlessm/eos-shell#3715]
