### PR TITLE
Don't allow to move the FBE window at all

### DIFF
--- a/gnome-initial-setup/gis-window.c
+++ b/gnome-initial-setup/gis-window.c
@@ -93,8 +93,13 @@ gis_window_realize (GtkWidget *widget)
   GTK_WIDGET_CLASS (gis_window_parent_class)->realize (widget);
 
   window = gtk_widget_get_window (widget);
-  /* disable WM functions except move */
-  gdk_window_set_functions (window, GDK_FUNC_MOVE);
+  /* disable all the WM functions */
+  gdk_window_set_functions (window, GDK_FUNC_ALL
+                            | GDK_FUNC_RESIZE
+                            | GDK_FUNC_MOVE
+                            | GDK_FUNC_MINIMIZE
+                            | GDK_FUNC_MAXIMIZE
+                            | GDK_FUNC_CLOSE);
 }
 
 static void


### PR DESCRIPTION
This could be interesting to fix upstream as well. I've commented on [GNOME bug 698665](https://bugzilla.gnome.org/show_bug.cgi?id=698665), in case the 'move' event was explicitly allowed for some reason.

[endlessm/eos-shell#3761]
