### PR TITLE
summary: add com.endlessm.FBE interface for tutorial integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ gnome-initial-setup/pages/location/cc-datetime-resources.[ch]
 gnome-initial-setup/pages/location/location-resources.[ch]
 gnome-initial-setup/pages/goa/goa-resources.[ch]
 gnome-initial-setup/pages/summary/summary-resources.[ch]
+gnome-initial-setup/pages/summary/fbe-generated.[ch]
 gnome-initial-setup/pages/endless-eula/endless-eula-resources.[ch]
 gnome-initial-setup/pages/location/geoclue.[ch]
 

--- a/gnome-initial-setup/pages/summary/Makefile.am
+++ b/gnome-initial-setup/pages/summary/Makefile.am
@@ -8,6 +8,13 @@ AM_CPPFLAGS = \
 
 BUILT_SOURCES =
 
+fbe-generated.c: fbe-generated.h
+fbe-generated.h: $(srcdir)/com.endlessm.FBE.xml
+	$(AM_V_GEN) gdbus-codegen		\
+	--interface-prefix=com.endlessm		\
+	--generate-c-code=fbe-generated $<
+BUILT_SOURCES += fbe-generated.c fbe-generated.h
+
 resource_files = $(shell glib-compile-resources --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/summary.gresource.xml)
 summary-resources.c: summary.gresource.xml $(resource_files)
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate-source $<
@@ -23,4 +30,7 @@ libgissummary_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) -I "$(srcdir)/../.."
 libgissummary_la_LIBADD = $(INITIAL_SETUP_LIBS)
 libgissummary_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined
 
-EXTRA_DIST = summary.gresource.xml $(resource_files)
+EXTRA_DIST =	\
+	com.endlessm.FBE.xml	\
+	summary.gresource.xml	\
+	$(resource_files)

--- a/gnome-initial-setup/pages/summary/com.endlessm.FBE.xml
+++ b/gnome-initial-setup/pages/summary/com.endlessm.FBE.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="com.endlessm.FBE">
+    <method name="TutorialExit" />
+  </interface>
+</node>

--- a/gnome-initial-setup/pages/summary/gis-summary-page.c
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.c
@@ -28,10 +28,12 @@
 #include "config.h"
 #include "summary-resources.h"
 #include "gis-summary-page.h"
+#include "fbe-generated.h"
 
 #include <glib/gstdio.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
+#include <gio/gdesktopappinfo.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -44,6 +46,9 @@
 struct _GisSummaryPagePrivate {
   ActUser *user_account;
   const gchar *user_password;
+
+  FBE *fbe_skeleton;
+  guint fbe_bus_name_id;
 };
 typedef struct _GisSummaryPagePrivate GisSummaryPagePrivate;
 
@@ -220,6 +225,15 @@ log_user_in (GisSummaryPage *page)
 }
 
 static void
+launch_tutorial (GisSummaryPage *summary)
+{
+  GAppInfo *app = G_APP_INFO (g_desktop_app_info_new ("com.endlessm.Tutorial.desktop"));
+  GAppLaunchContext *launch_context = G_APP_LAUNCH_CONTEXT (gdk_display_get_app_launch_context (gdk_display_get_default ()));
+  g_app_info_launch (app, NULL, launch_context, NULL);
+  g_object_unref (launch_context);
+}
+
+static void
 done_cb (GtkButton *button, GisSummaryPage *page)
 {
   gchar *file;
@@ -232,7 +246,7 @@ done_cb (GtkButton *button, GisSummaryPage *page)
   switch (gis_driver_get_mode (GIS_PAGE (page)->driver))
     {
     case GIS_DRIVER_MODE_NEW_USER:
-      log_user_in (page);
+      launch_tutorial (page);
       break;
     case GIS_DRIVER_MODE_EXISTING_USER:
       gis_add_setup_done_file ();
@@ -335,6 +349,60 @@ update_distro_name (GisSummaryPage *page)
     }
 }
 
+static gboolean
+handle_tutorial_exit (GDBusInterfaceSkeleton *skeleton,
+                      GDBusMethodInvocation  *invocation,
+                      gpointer                user_data)
+{
+  GisSummaryPage *summary = user_data;
+
+  log_user_in (summary);
+
+  fbe_complete_tutorial_exit (FBE (skeleton), invocation);
+  return TRUE;
+}
+
+static void
+fbe_name_lost (GDBusConnection *connection,
+               const gchar *name,
+               gpointer user_data)
+{
+  GisSummaryPage *summary = user_data;
+  GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (summary);
+  g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (priv->fbe_skeleton));
+}
+
+static void
+fbe_bus_acquired (GDBusConnection *connection,
+                  const gchar *name,
+                  gpointer user_data)
+{
+  GisSummaryPage *summary = user_data;
+  GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (summary);
+  g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (priv->fbe_skeleton),
+                                    connection,
+                                    "/com/endlessm/FBE",
+                                    NULL);
+}
+
+static void
+export_on_dbus (GisSummaryPage *summary)
+{
+  GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (summary);
+
+  priv->fbe_bus_name_id = g_bus_own_name (G_BUS_TYPE_SESSION,
+                                          "com.endlessm.FBE",
+                                          G_BUS_NAME_OWNER_FLAGS_NONE,
+                                          fbe_bus_acquired,
+                                          NULL, /* name_acquired handler */
+                                          fbe_name_lost,
+                                          summary, NULL);
+
+  priv->fbe_skeleton = fbe_skeleton_new ();
+  g_signal_connect (priv->fbe_skeleton, "handle-tutorial-exit",
+                    G_CALLBACK (handle_tutorial_exit), summary);
+}
+
 static void
 gis_summary_page_constructed (GObject *object)
 {
@@ -344,11 +412,34 @@ gis_summary_page_constructed (GObject *object)
 
   gtk_container_add (GTK_CONTAINER (page), WID ("summary-page"));
   update_distro_name (page);
+  export_on_dbus (page);
   g_signal_connect (WID("summary-start-button"), "clicked", G_CALLBACK (done_cb), page);
 
   gis_page_set_complete (GIS_PAGE (page), TRUE);
 
   gtk_widget_show (GTK_WIDGET (page));
+}
+
+static void
+gis_summary_page_dispose (GObject *object)
+{
+  GisSummaryPage *page = GIS_SUMMARY_PAGE (object);
+  GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (page);
+
+  G_OBJECT_CLASS (gis_summary_page_parent_class)->dispose (object);
+
+  if (priv->fbe_skeleton)
+    {
+      g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (priv->fbe_skeleton));
+      g_object_unref (priv->fbe_skeleton);
+      priv->fbe_skeleton = NULL;
+    }
+
+  if (priv->fbe_bus_name_id != 0)
+    {
+      g_bus_unown_name (priv->fbe_bus_name_id);
+      priv->fbe_bus_name_id = 0;
+    }
 }
 
 static void
@@ -369,6 +460,7 @@ gis_summary_page_class_init (GisSummaryPageClass *klass)
   page_class->locale_changed = gis_summary_page_locale_changed;
   page_class->shown = gis_summary_page_shown;
   object_class->constructed = gis_summary_page_constructed;
+  object_class->dispose = gis_summary_page_dispose;
 }
 
 static void


### PR DESCRIPTION
Export a simple method on the bus for the tutorial application to call
back into the FBE and quit it.

endlessm/eos-shell#3654
