### PR TITLE
endless-eula: allow keyboard navigation

### DIFF
--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
@@ -19,7 +19,7 @@
           <object class="GtkCheckButton" id="metrics-checkbutton">
             <property name="label" translatable="yes">Enable metrics collection.</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="xalign">0</property>
             <property name="active">True</property>
@@ -34,7 +34,7 @@
         <child>
           <object class="GtkLabel" id="metrics-privacy-label">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
             <property name="label" translatable="yes">&lt;a href='metrics-privacy-policy'&gt;Click here&lt;/a&gt; to see our privacy policy</property>
             <property name="use_markup">True</property>
           </object>


### PR DESCRIPTION
We were disabling keyboard navigation in the Endless EULA page.

[endlessm/eos-shell#3285]
