### PR TITLE
location: Fix date corruption when on the last day of the month

### DIFF
--- a/gnome-initial-setup/pages/location/gis-location-page.c
+++ b/gnome-initial-setup/pages/location/gis-location-page.c
@@ -605,7 +605,6 @@ gis_location_page_constructed (GObject *object)
   DateEndianess endianess;
   GtkWidget *widget;
   gint i;
-  guint num_days;
   GtkAdjustment *adjustment;
   gchar *time_buttons[] = { "hour_up_button", "hour_down_button",
                             "min_up_button", "min_down_button" };
@@ -716,10 +715,8 @@ gis_location_page_constructed (GObject *object)
   g_signal_connect (widget, "changed",
                     G_CALLBACK (month_year_changed), page);
 
-  num_days = g_date_get_days_in_month (g_date_time_get_month (priv->date),
-                                       g_date_time_get_year (priv->date));
   adjustment = (GtkAdjustment *) gtk_adjustment_new (g_date_time_get_day_of_month (priv->date),
-                                                     1, num_days, 1, 10, 1);
+                                                     1, 50, 1, 10, 1);
   widget = WID ("day-spinbutton");
   gtk_spin_button_set_adjustment (GTK_SPIN_BUTTON (widget), adjustment);
 


### PR DESCRIPTION
When we constructed the adjustment for the day spinbutton, we created it
with num_days as the upper bound, but the upper bound is exclusive, not
inclusive! As such, if you were on the last day of the month, we'd push
you back to the closest upper bound, which was the day before.

Thankfully, when we have the user change the month in
month_year_changed, we actually get the upper get right by adding on an
additional 1. So we first make it too low, and then we set it back to
the correct value immediately afterwards.

To fix this, set an unreasonably large upper bound to
start out with. Since we call month_year_changed almost immediately
afterwards, the lower bound will be set properly and we'll be fine.

[endlessm/eos-shell#3249]
