### PR TITLE
GIS: Updated the code to use the new tutorial's dbus format

### DIFF
--- a/gnome-initial-setup/pages/summary/com.endlessm.Tutorial.FBERemote.xml
+++ b/gnome-initial-setup/pages/summary/com.endlessm.Tutorial.FBERemote.xml
@@ -2,6 +2,8 @@
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
   <interface name="com.endlessm.Tutorial.FBERemote">
-    <method name="PlayTutorial" />
+    <method name="PlayTutorial">
+      <arg type="b" direction="in" name="ignore_exit"/>
+    </method>
   </interface>
 </node>

--- a/gnome-initial-setup/pages/summary/gis-summary-page.c
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.c
@@ -276,7 +276,7 @@ launch_tutorial (GisSummaryPage *summary)
   /* use g_dbus_proxy_call() to specify a custom timeout */
   g_dbus_proxy_call (G_DBUS_PROXY (fbe_remote),
                      "PlayTutorial",
-                     g_variant_new ("()"),
+                     g_variant_new ("(b)", TRUE),
                      G_DBUS_CALL_FLAGS_NONE,
                      G_MAXINT,
                      NULL, /* cancellable */


### PR DESCRIPTION
Since the tutorial now has an extra parameter that it expects, we needed
to update the client-side code for it in GIS.

[endlessm/eos-shell#3916]