### PR TITLE
Get time format from locale instead of personality file

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -304,6 +304,7 @@ gis_driver_read_personality_file (GisDriver *driver)
   priv->lang_override = language;
   if (language) {
     setlocale (LC_MESSAGES, language);
+    setlocale (LC_TIME, language);
   }
 
   g_free (priv->default_timezone);

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -39,7 +39,6 @@
 #define PERSONALITY_KEY "PersonalityName"
 #define LANGUAGE_KEY "DefaultLanguage"
 #define TIMEZONE_KEY "DefaultTimezone"
-#define TIMEFORMAT_KEY "DefaultTimeFormat"
 
 /* Statically include this for now. Maybe later
  * we'll generate this from glib-mkenums. */
@@ -85,7 +84,6 @@ struct _GisDriverPrivate {
   gchar *lang_id;
   gchar *lang_override;
   gchar *default_timezone;
-  gchar *default_time_format;
 
   GisDriverMode mode;
 };
@@ -103,7 +101,6 @@ gis_driver_finalize (GObject *object)
   g_free (priv->lang_id);
   g_free (priv->lang_override);
   g_free (priv->default_timezone);
-  g_free (priv->default_time_format);
 
   G_OBJECT_CLASS (gis_driver_parent_class)->finalize (object);
 }
@@ -220,13 +217,6 @@ gis_driver_get_default_timezone (GisDriver *driver)
   return priv->default_timezone;
 }
 
-const gchar *
-gis_driver_get_default_time_format (GisDriver *driver)
-{
-  GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
-  return priv->default_time_format;
-}
-
 static void
 gis_driver_get_property (GObject      *object,
                          guint         prop_id,
@@ -284,7 +274,6 @@ gis_driver_read_personality_file (GisDriver *driver)
   gchar *personality = NULL;
   gchar *language = NULL;
   gchar *timezone = NULL;
-  gchar *time_format = NULL;
 
   if (g_key_file_load_from_file (keyfile, PERSONALITY_FILE_PATH,
                                  G_KEY_FILE_NONE, NULL)) {
@@ -294,8 +283,6 @@ gis_driver_read_personality_file (GisDriver *driver)
                                       LANGUAGE_KEY, NULL);
     timezone = g_key_file_get_string (keyfile, SETUP_CONFIG_GROUP,
                                       TIMEZONE_KEY, NULL);
-    time_format = g_key_file_get_string (keyfile, SETUP_CONFIG_GROUP,
-                                         TIMEFORMAT_KEY, NULL);
   }
 
   priv->personality = personality;
@@ -309,7 +296,6 @@ gis_driver_read_personality_file (GisDriver *driver)
 
   g_free (priv->default_timezone);
   priv->default_timezone = timezone;
-  priv->default_time_format = time_format;
 
   g_key_file_free (keyfile);
 }

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -82,8 +82,6 @@ const gchar *gis_driver_get_personality (GisDriver *driver);
 
 const gchar *gis_driver_get_default_timezone (GisDriver *driver);
 
-const gchar *gis_driver_get_default_time_format (GisDriver *driver);
-
 GisDriverMode gis_driver_get_mode (GisDriver *driver);
 
 void gis_driver_add_page (GisDriver *driver,

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -132,6 +132,7 @@ set_language (GisLanguagePage *page)
   driver = GIS_PAGE (page)->driver;
 
   setlocale (LC_MESSAGES, priv->new_locale_id);
+  setlocale (LC_TIME, priv->new_locale_id);
   gis_driver_locale_changed (driver);
 
   /* gis spawns processes that also need to be localised */


### PR DESCRIPTION
Kill off DefaultTimeFormat from the personality file by querying the locale via nl_langinfo() instead.

[endlessm/eos-shell#4558]