### PR TITLE
GIS: Possible fix for barcode sometimes not showing up on initial boot

### DIFF
--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -209,9 +209,15 @@ static gchar *
 create_serial_barcode (const gchar *serial)
 {
   gchar *savefile;
+  const gchar *cache_dir;
   struct zint_symbol *barcode;
 
-  savefile = g_build_filename (g_get_user_cache_dir (), "product_serial.png", NULL);
+  cache_dir = g_get_user_cache_dir ();
+
+  /* Create the directory if it's missing */
+  g_mkdir_with_parents (cache_dir, 0755);
+
+  savefile = g_build_filename (cache_dir, "product_serial.png", NULL);
 
   barcode = ZBarcode_Create();
   strncpy ((char *) barcode->outfile, savefile, 4096);


### PR DESCRIPTION
While we can't pinpoint the reason for the barcode disappearing, the
best guess is that sometiumes the cache dir is being created by some
other method that might encounter a race condition with GIS so this fix
makes sure that we have that directory before trying to write the
barcode image to it.

[endlessm/eos-shell#4708]