### PR TITLE
keyboard: Remove page icon

### DIFF
--- a/gnome-initial-setup/pages/keyboard/cc-keyboard-query.c
+++ b/gnome-initial-setup/pages/keyboard/cc-keyboard-query.c
@@ -39,7 +39,7 @@ typedef struct
   GtkWidget *heading;
   GtkWidget *keyrow;
   GtkWidget *buttons;
-  GtkWidget *add_button;
+  GtkWidget *select_button;
 
   GnomeXkbInfo *xkb_data;
 } CcKeyboardQueryPrivate;
@@ -192,7 +192,7 @@ cc_keyboard_query_layout_result (CcKeyboardQuery *self,
   gtk_label_set_label (GTK_LABEL (priv->heading), result_message);
   gtk_widget_hide (priv->buttons);
   gtk_widget_hide (priv->keyrow);
-  gtk_widget_set_sensitive (priv->add_button, TRUE);
+  gtk_widget_set_sensitive (priv->select_button, TRUE);
 
   g_free (result_message);
 }
@@ -283,7 +283,7 @@ cc_keyboard_query_class_init (CcKeyboardQueryClass *klass)
   gtk_widget_class_bind_template_child_private (widget_class, CcKeyboardQuery, vbox);
   gtk_widget_class_bind_template_child_private (widget_class, CcKeyboardQuery, heading);
   gtk_widget_class_bind_template_child_private (widget_class, CcKeyboardQuery, buttons);
-  gtk_widget_class_bind_template_child_private (widget_class, CcKeyboardQuery, add_button);
+  gtk_widget_class_bind_template_child_private (widget_class, CcKeyboardQuery, select_button);
   gtk_widget_class_bind_template_callback (widget_class, have_key);
   gtk_widget_class_bind_template_callback (widget_class, no_have_key);
   gtk_widget_class_bind_template_callback (widget_class, key_press_event);

--- a/gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui
+++ b/gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui
@@ -9,27 +9,19 @@
         <property name="valign">fill</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkLabel" id="title">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <property name="valign">start</property>
-            <property name="label" translatable="yes">Typing</property>
-            <attributes>
-              <attribute name="weight" value="bold"/>
-              <attribute name="scale" value="1.8"/>
-            </attributes>
-          </object>
-        </child>
-        <child>
           <object class="GtkLabel" id="subtitle">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_top">6</property>
             <property name="label" translatable="yes">Select your keyboard layout or an input method.</property>
-            <property name="justify">left</property>
-            <property name="wrap">True</property>
-            <property name="max-width-chars">50</property>
+	    <property name="hexpand">False</property>
+	    <property name="halign">start</property>
+	    <property name="valign">start</property>
+	    <property name="xalign">0</property>
+	    <property name="yalign">0</property>
+	    <attributes>
+	      <attribute name="weight" value="bold"/>
+	      <attribute name="scale" value="1.2"/>
+	    </attributes>
           </object>
         </child>
         <child>

--- a/gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui
+++ b/gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui
@@ -9,22 +9,9 @@
         <property name="valign">fill</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkImage" id="image1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">40</property>
-            <property name="pixel_size">96</property>
-            <property name="icon_name">input-keyboard-symbolic</property>
-            <style>
-              <class name="dim-label" />
-            </style>
-          </object>
-        </child>
-        <child>
           <object class="GtkLabel" id="title">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_top">18</property>
             <property name="halign">center</property>
             <property name="valign">start</property>
             <property name="label" translatable="yes">Typing</property>

--- a/gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui
+++ b/gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui
@@ -12,7 +12,7 @@
           <object class="GtkLabel" id="subtitle">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Select your keyboard layout or an input method.</property>
+            <property name="label" translatable="yes">Select your keyboard layout</property>
 	    <property name="hexpand">False</property>
 	    <property name="halign">start</property>
 	    <property name="valign">start</property>

--- a/gnome-initial-setup/pages/keyboard/keyboard-detector.ui
+++ b/gnome-initial-setup/pages/keyboard/keyboard-detector.ui
@@ -81,7 +81,7 @@
               <object class="GtkButton" id="select_button">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
-                <property name="label">Select</property>
+                <property name="label" translatable="yes">Select</property>
                 <property name="use_underline" >True</property>
               </object>
             </child>

--- a/gnome-initial-setup/pages/keyboard/keyboard-detector.ui
+++ b/gnome-initial-setup/pages/keyboard/keyboard-detector.ui
@@ -78,11 +78,10 @@
               </object>
             </child>
             <child>
-              <object class="GtkButton" id="add_button">
+              <object class="GtkButton" id="select_button">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
-                <property name="label">gtk-add</property>
-                <property name="use_stock">True</property>
+                <property name="label">Select</property>
                 <property name="use_underline" >True</property>
               </object>
             </child>
@@ -91,7 +90,7 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-5">add_button</action-widget>
+      <action-widget response="-5">select_button</action-widget>
       <action-widget response="-6">cancel_button</action-widget>
     </action-widgets>
   </template>

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-13 16:12-0700\n"
-"PO-Revision-Date: 2015-03-13 23:22+0000\n"
+"POT-Creation-Date: 2015-03-13 16:30-0700\n"
+"PO-Revision-Date: 2015-03-13 23:38+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: Arabic (http://www.transifex.com/projects/p/gnome-initial-setup/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -417,6 +417,10 @@ msgstr "المساعدة في معرفة تصميم لوحة المفاتيح ا
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:1
 msgid "Detect Keyboard Layout..."
 msgstr "اكتشاف تصميم لوحة المفاتيح..."
+
+#: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:3
+msgid "Select"
+msgstr "اختر"
 
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:205
 msgid "No languages found"

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,24 +1,23 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Khaled Hosny <khaledhosny@eglug.org>, 2012-2013
+# Roddy Shuler <roddy@endlessm.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 12:37+0100\n"
-"PO-Revision-Date: 2014-12-17 00:26+0000\n"
-"Last-Translator: endlessmobile_build <philip@endlessm.com>\n"
-"Language-Team: Arabic (http://www.transifex.com/projects/p/gnome-initial-"
-"setup/language/ar/)\n"
-"Language: ar\n"
+"POT-Creation-Date: 2015-03-13 16:12-0700\n"
+"PO-Revision-Date: 2015-03-13 23:22+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: Arabic (http://www.transifex.com/projects/p/gnome-initial-setup/language/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
-"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #: ../data/gnome-initial-setup.desktop.in.in.h:1
 #: ../data/gnome-initial-setup-first-login.desktop.in.in.h:1
@@ -51,27 +50,27 @@ msgid "No password"
 msgstr "بلا كلمة السر"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.c:331
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:436
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:445
 msgid "Passwords do not match"
 msgstr "لا تتطابق كلمتا السر"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:555
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:564
 msgid "Failed to register account"
 msgstr "فشل تسجيل الحساب"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:763
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:772
 msgid "No supported way to authenticate with this domain"
 msgstr "لا توجد طريقة مدعومة للاستيثاق مع هذا النطاق"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:803
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:812
 msgid "Failed to join domain"
 msgstr "فشل الانضمام إلى النطاق"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:871
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:880
 msgid "Failed to log into domain"
 msgstr "فشل الولوج إلى النطاق"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:1296
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:1305
 msgid "Login"
 msgstr "الولوج"
 
@@ -89,11 +88,7 @@ msgid ""
 "upper case letters. If the caps lock key is pressed, the symbol ⚠ will "
 "appear at the right side of the space in which you're writing. You'll need "
 "to type in this password identically each time you access your account."
-msgstr ""
-"قد تحتاج إلى تدوين كلمة المرور الخاصة بك. تأكد من الانتباه إلى الأحرف "
-"الكبيرة. إذا كان مفتاح caps lock قيد التشغيل، فسيظهر الرمز ⚠ في الجانب "
-"الأيمن من المساحة تكتب فيها. سوف يتعين عليك إدخال كلمة المرور هذه بشكل "
-"متطابق في كل مرة تدخل فيها إلى حسابك."
+msgstr "قد تحتاج إلى تدوين كلمة المرور الخاصة بك. تأكد من الانتباه إلى الأحرف الكبيرة. إذا كان مفتاح caps lock قيد التشغيل، فسيظهر الرمز ⚠ في الجانب الأيمن من المساحة تكتب فيها. سوف يتعين عليك إدخال كلمة المرور هذه بشكل متطابق في كل مرة تدخل فيها إلى حسابك."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:4
 msgid "_Full Name"
@@ -107,8 +102,7 @@ msgstr "اسم المست_خدم"
 msgid ""
 "The username will be used to name your personal folder, and it cannot be "
 "changed."
-msgstr ""
-"سيتم استخدام اسم المستخدم لتسمية المجلد الشخصي الخاص بك، ولن يمكن تغييره."
+msgstr "سيتم استخدام اسم المستخدم لتسمية المجلد الشخصي الخاص بك، ولن يمكن تغييره."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:7
 msgid "_Password"
@@ -120,11 +114,9 @@ msgstr "أكّ_د كلمة السّر"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:9
 msgid ""
-"To make your password more secure, you can use letters and numbers together. "
-"This is optional."
-msgstr ""
-"لجعل كلمة المرور الخاصة بك أكثر أمناً، يمكنك استخدام الحروف والأرقام معاً. "
-"وهذا أمر اختياري."
+"To make your password more secure, you can use letters and numbers together."
+" This is optional."
+msgstr "لجعل كلمة المرور الخاصة بك أكثر أمناً، يمكنك استخدام الحروف والأرقام معاً. وهذا أمر اختياري."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:10
 msgid "To continue, please make sure you fill in all the blanks."
@@ -164,10 +156,7 @@ msgid ""
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here, and choose a unique computer\n"
 "name for your computer."
-msgstr ""
-"تحتاج أن تكون مسجّلا في النطاق لاستخدام ولوج المؤسسات على هذا الحاسوب.\n"
-"من فضلك اطلب من مدير الشبكة أن يكتب كلمة سر النطاق هنا، و اختر اسمًا\n"
-"فريدًا لحاسوبك."
+msgstr "تحتاج أن تكون مسجّلا في النطاق لاستخدام ولوج المؤسسات على هذا الحاسوب.\nمن فضلك اطلب من مدير الشبكة أن يكتب كلمة سر النطاق هنا، و اختر اسمًا\nفريدًا لحاسوبك."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:22
 msgid "_Computer"
@@ -255,11 +244,7 @@ msgid ""
 " ➣ letters from the English alphabet\n"
 " ➣ digits\n"
 " ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"يجب أن لا يتعدى اسم المستخدم:\n"
-" ◂ الحروف الإنجليزية\n"
-" ◂ الأرقام\n"
-" ◂ أي من الحروف: '.' و '-' و '_'"
+msgstr "يجب أن لا يتعدى اسم المستخدم:\n ◂ الحروف الإنجليزية\n ◂ الأرقام\n ◂ أي من الحروف: '.' و '-' و '_'"
 
 #: ../gnome-initial-setup/pages/display/gis-display-page.c:281
 msgid "Display"
@@ -302,9 +287,7 @@ msgstr "الرجاء قراءة شروط الاستخدام التالية بع�
 msgid ""
 "By clicking \"Accept and continue,\" you acknowledge that you have read, "
 "understood, and agree to be bound by the following terms and conditions."
-msgstr ""
-"بالنقر على \"قبول ومتابعة\"، فإنك تقرّ بأنك قد قرأت وفهمت الشروط والبنود "
-"التالية وتوافق على الالتزام بها."
+msgstr "بالنقر على \"قبول ومتابعة\"، فإنك تقرّ بأنك قد قرأت وفهمت الشروط والبنود التالية وتوافق على الالتزام بها."
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:3
 msgid "Help make Endless better for everyone"
@@ -314,9 +297,7 @@ msgstr "المساعدة في تحسين Endless لمصلحة الجميع"
 msgid ""
 "Automatically save and send usage statistics and problem reports to Endless "
 "Mobile. All data is anonymous."
-msgstr ""
-"تخزين وإرسال تلقائي لإحصائيات الاستخدام وتقارير المشاكل إلى موبايل Endless. "
-"يتم التعامل مع كافة البيانات بدون الكشف عن هوية الشخص المرسل."
+msgstr "تخزين وإرسال تلقائي لإحصائيات الاستخدام وتقارير المشاكل إلى موبايل Endless. يتم التعامل مع كافة البيانات بدون الكشف عن هوية الشخص المرسل."
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1
@@ -387,52 +368,49 @@ msgstr "اتّصل ببياناتك الموجودة على السحاب"
 msgid ""
 "Adding accounts will allow you to transparently connect to your online "
 "photos, contacts, mail, and more."
-msgstr ""
-"إضافة الحسابات سيتيح لك الاتصال لصورك و معارفك و بريدك على الشبكة، و غيرها."
+msgstr "إضافة الحسابات سيتيح لك الاتصال لصورك و معارفك و بريدك على الشبكة، و غيرها."
 
 #: ../gnome-initial-setup/pages/goa/gis-goa-page.ui.h:3
 msgid "_Add Account"
 msgstr "أ_ضف حسابًا"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:242
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:241
 msgid "Preview"
 msgstr "ﻢﻋﺎﻴﻧﺓ"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:302
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:298
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:188
 msgid "More…"
 msgstr "المزيد…"
 
 #. Translators: a search for input methods or keyboard layouts
 #. * did not yield any results
-#.
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:323
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:319
 msgid "No inputs found"
 msgstr "ﻻ ﻱﻮﺟﺩ ﺄﻳ ﻢﺻﺍﺩﺭ ﺇﺪﺧﺎﻟ"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:198
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:190
 msgid "Your keyboard layout seems to be:"
 msgstr "يبدو أن تصميم لوحة المفاتيح الخاصة بك هو:"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:313
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:304
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:2
 msgid "Please press one of the following keys:"
 msgstr "الرجاء الضغط على أحد المفاتيح التالية:"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:314
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:305
 msgid "Is the following key present on your keyboard?"
 msgstr "هل المفتاح التالي متوفر على لوحة المفاتيح الخاصة بك؟"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:255
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:256
 msgid "Typing"
 msgstr "ﺎﻠﻜﺗﺎﺑﺓ"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
-msgid "Select your keyboard layout or an input method."
-msgstr "ﺎﺨﺗﺭ ﺖﺨﻄﻴﻃ ﻝﻮﺣﺓ ﺎﻠﻤﻓﺎﺘﻴﺣ ﻭ ﻁﺮﻴﻗﺓ ﺍﻹﺪﺧﺎﻟ."
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+msgid "Select your keyboard layout"
+msgstr "ﺎﺨﺗﺭ ﺖﺨﻄﻴﻃ ﻝﻮﺣﺓ ﺎﻠﻤﻓﺎﺘﻴﺣ"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:3
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
 msgid "Help detect my keyboard layout"
 msgstr "المساعدة في معرفة تصميم لوحة المفاتيح الخاصة بي"
 
@@ -444,16 +422,16 @@ msgstr "اكتشاف تصميم لوحة المفاتيح..."
 msgid "No languages found"
 msgstr "لا يوجد أي لغات"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:524
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:531
 msgid "Welcome"
 msgstr "مرحبًا"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:528
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:535
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:2
 msgid "Welcome to Endless!"
 msgstr "مرحباً بك في اللانهاية!"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:530
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:537
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:3
 msgid "Let's set up your computer..."
 msgstr "فلنقم بإعداد جهازك الكمبيوتر..."
@@ -462,11 +440,11 @@ msgstr "فلنقم بإعداد جهازك الكمبيوتر..."
 msgid "Power Off"
 msgstr "إيقاف التشغيل"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:643
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:662
 msgid "Search for a location"
 msgstr "ابحث عن مكان"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:778
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:797
 #: ../gnome-initial-setup/pages/location/gis-location-page.ui.h:15
 msgid "Location"
 msgstr "المكان"
@@ -576,21 +554,16 @@ msgstr "الشبكات اللاسلكية"
 msgid ""
 "Do you have wireless internet (WiFi)? If you do, connect your computer to "
 "the internet by clicking on the name of your WiFi network and entering the "
-"network password. This password may be different from your computer password."
-msgstr ""
-"هل لديك إنترنت لاسلكي (واي فاي)؟ إذا كان لديك، قم بتوصيل جهاز الكمبيوتر "
-"الخاص بك بالإنترنت من خلال النقر على اسم الشبكة اللاسلكية الخاصة بك وإدخال "
-"كلمة مرور الشبكة. قد تختلف كلمة المرور هذه عن كلمة المرور الخاصة بكمبيوترك."
+"network password. This password may be different from your computer "
+"password."
+msgstr "هل لديك إنترنت لاسلكي (واي فاي)؟ إذا كان لديك، قم بتوصيل جهاز الكمبيوتر الخاص بك بالإنترنت من خلال النقر على اسم الشبكة اللاسلكية الخاصة بك وإدخال كلمة مرور الشبكة. قد تختلف كلمة المرور هذه عن كلمة المرور الخاصة بكمبيوترك."
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:3
 msgid ""
 "TIP: You can use your computer without internet if you do not have a "
-"connection now. If you get an internet connection in the future, you can set "
-"it up in \"Network Settings.\""
-msgstr ""
-"نصيحة: يمكنك استخدام جهاز الكمبيوتر الخاص بك من دون إنترنت إذا لم يكن لديك "
-"اتصال الآن. إذا توفر لديك اتصال بالإنترنت في المستقبل، يمكنك إعداده في "
-"\"إعدادات الشبكة.\""
+"connection now. If you get an internet connection in the future, you can set"
+" it up in \"Network Settings.\""
+msgstr "نصيحة: يمكنك استخدام جهاز الكمبيوتر الخاص بك من دون إنترنت إذا لم يكن لديك اتصال الآن. إذا توفر لديك اتصال بالإنترنت في المستقبل، يمكنك إعداده في \"إعدادات الشبكة.\""
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:4
 msgid "No wireless available"
@@ -600,12 +573,12 @@ msgstr "لا تتوفر شبكات لاسلكية"
 msgid "_Skip WiFi setup"
 msgstr "_تخطي إعداد شبكة الواي فاي"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:392
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:394
 #, c-format
 msgid "_Start using %s"
 msgstr "اب_دأ باستخدام %s"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:418
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:420
 msgid "Thank You"
 msgstr "شكرًا"
 
@@ -620,12 +593,3 @@ msgstr "يمكنك تغيير أي من هذه الخيارات من ”الإع
 #: ../gnome-initial-setup/pages/summary/gis-summary-page.ui.h:3
 msgid "_Start using GNOME 3"
 msgstr "اب_دأ باستخدام جنوم 3"
-
-#~ msgid "Other"
-#~ msgstr "أخرى"
-
-#~ msgid "Keyboard Layouts"
-#~ msgstr "تخطيطات لوحة المفاتيح"
-
-#~ msgid "Add a Keyboard Layout"
-#~ msgstr "إضافة تخطيط للوحة المفاتيح"

--- a/po/es.po
+++ b/po/es.po
@@ -1,8 +1,9 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
+# c.sanchez <cassandra@endlessm.com>, 2014
 # c.sanchez <cassandra@endlessm.com>, 2014
 # Daniel Mustieles <daniel.mustieles@gmail.com>, 2012-2014
 # Eddy Alegria <eddy@endlessm.com>, 2014
@@ -10,20 +11,19 @@
 # Joel Gil Leon <joel@endlessm.com>, 2014
 # Nuritzi Sanchez <ns@endlessm.com>, 2014
 # Philip Chimento <philip.chimento@gmail.com>, 2014
-# Roddy Shuler <roddy@endlessm.com>, 2014
+# Roddy Shuler <roddy@endlessm.com>, 2014-2015
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 12:37+0100\n"
-"PO-Revision-Date: 2014-12-22 19:04+0000\n"
-"Last-Translator: Nuritzi Sanchez <ns@endlessm.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/projects/p/gnome-initial-"
-"setup/language/es/)\n"
-"Language: es\n"
+"POT-Creation-Date: 2015-03-13 16:12-0700\n"
+"PO-Revision-Date: 2015-03-13 23:18+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/projects/p/gnome-initial-setup/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../data/gnome-initial-setup.desktop.in.in.h:1
@@ -57,27 +57,27 @@ msgid "No password"
 msgstr "Sin contraseña"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.c:331
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:436
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:445
 msgid "Passwords do not match"
 msgstr "Las contraseñas no coinciden"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:555
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:564
 msgid "Failed to register account"
 msgstr "Falló al registrar la cuenta"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:763
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:772
 msgid "No supported way to authenticate with this domain"
 msgstr "No hay una manera soportada de autenticar con este dominio"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:803
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:812
 msgid "Failed to join domain"
 msgstr "Falló al unirse al dominio"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:871
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:880
 msgid "Failed to log into domain"
 msgstr "Falló al iniciar sesión en el dominio"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:1296
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:1305
 msgid "Login"
 msgstr "Iniciar sesión"
 
@@ -95,11 +95,7 @@ msgid ""
 "upper case letters. If the caps lock key is pressed, the symbol ⚠ will "
 "appear at the right side of the space in which you're writing. You'll need "
 "to type in this password identically each time you access your account."
-msgstr ""
-"Si quieres, puedes anotar tu contraseña para recordarla. Presta atención a "
-"las mayúsculas: si la tecla que las activa está presionada, aparecerá este "
-"símbolo ⚠ a la derecha del espacio en el que estás escribiendo. Cada vez que "
-"quieras entrar a tu cuenta deberás escribir tu contraseña idénticamente."
+msgstr "Si quieres, puedes anotar tu contraseña para recordarla. Presta atención a las mayúsculas: si la tecla que las activa está presionada, aparecerá este símbolo ⚠ a la derecha del espacio en el que estás escribiendo. Cada vez que quieras entrar a tu cuenta deberás escribir tu contraseña idénticamente."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:4
 msgid "_Full Name"
@@ -113,9 +109,7 @@ msgstr "Nombre de _usuario"
 msgid ""
 "The username will be used to name your personal folder, and it cannot be "
 "changed."
-msgstr ""
-"Tu nombre de usuario será usado para nombrar tu carpeta personal y no se "
-"puede cambiar después."
+msgstr "Tu nombre de usuario será usado para nombrar tu carpeta personal y no se puede cambiar después."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:7
 msgid "_Password"
@@ -127,8 +121,8 @@ msgstr "_Confirmar contraseña"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:9
 msgid ""
-"To make your password more secure, you can use letters and numbers together. "
-"This is optional."
+"To make your password more secure, you can use letters and numbers together."
+" This is optional."
 msgstr "Puedes mezclar letras y números para que tu contraseña sea más segura."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:10
@@ -169,11 +163,7 @@ msgid ""
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here, and choose a unique computer\n"
 "name for your computer."
-msgstr ""
-"Para empezar a usar cuentas corporativas, esta computadora necesitará estar\n"
-"incluida en el dominio empresarial. El administrador de tu red necesitará\n"
-"entrar su contraseña del dominio aquí y elegir un nombre único\n"
-"para tu computadora."
+msgstr "Para empezar a usar cuentas corporativas, esta computadora necesitará estar\nincluida en el dominio empresarial. El administrador de tu red necesitará\nentrar su contraseña del dominio aquí y elegir un nombre único\npara tu computadora."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:22
 msgid "_Computer"
@@ -261,11 +251,7 @@ msgid ""
 " ➣ letters from the English alphabet\n"
 " ➣ digits\n"
 " ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"El nombre de usuario debe consistir de:\n"
-" ➣ letras del alfabeto inglés\n"
-" ➣ dígitos\n"
-" ➣ cualquiera de los caracteres «.», «-» y «_»"
+msgstr "El nombre de usuario debe consistir de:\n ➣ letras del alfabeto inglés\n ➣ dígitos\n ➣ cualquiera de los caracteres «.», «-» y «_»"
 
 #: ../gnome-initial-setup/pages/display/gis-display-page.c:281
 msgid "Display"
@@ -308,9 +294,7 @@ msgstr "Por favor lee los siguientes términos de uso cuidadosamente"
 msgid ""
 "By clicking \"Accept and continue,\" you acknowledge that you have read, "
 "understood, and agree to be bound by the following terms and conditions."
-msgstr ""
-"Al hacer clic en \"Aceptar y continuar,\" reconoces que has leído, entendido "
-"y aceptado que quedarás vinculado por los siguientes términos y condiciones."
+msgstr "Al hacer clic en \"Aceptar y continuar,\" reconoces que has leído, entendido y aceptado que quedarás vinculado por los siguientes términos y condiciones."
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:3
 msgid "Help make Endless better for everyone"
@@ -320,9 +304,7 @@ msgstr "Ayuda a hacer Endless mejor para todos"
 msgid ""
 "Automatically save and send usage statistics and problem reports to Endless "
 "Mobile. All data is anonymous."
-msgstr ""
-"Automáticamente guarda y envía estadísticas de uso e informes de problemas a "
-"Endless Mobile. Toda la información mandada es anónima."
+msgstr "Automáticamente guarda y envía estadísticas de uso e informes de problemas a Endless Mobile. Toda la información mandada es anónima."
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1
@@ -333,9 +315,7 @@ msgstr "Acuerdo de licencia"
 msgid ""
 "I have _agreed to the terms and conditions in this end user license "
 "agreement."
-msgstr ""
-"He leído y _acepto los términos y las condiciones de este contrato de "
-"licencia del usuario final."
+msgstr "He leído y _acepto los términos y las condiciones de este contrato de licencia del usuario final."
 
 #: ../gnome-initial-setup/pages/goa/cc-online-accounts-add-account-dialog.c:200
 msgctxt "Online Account"
@@ -395,53 +375,49 @@ msgstr "Conectate a tus datos en la nube"
 msgid ""
 "Adding accounts will allow you to transparently connect to your online "
 "photos, contacts, mail, and more."
-msgstr ""
-"Añadiendo las cuentas de tus apps en línea favoritas, podrás acceder "
-"fácilmente a tus fotos, contactos, correo y más."
+msgstr "Añadiendo las cuentas de tus apps en línea favoritas, podrás acceder fácilmente a tus fotos, contactos, correo y más."
 
 #: ../gnome-initial-setup/pages/goa/gis-goa-page.ui.h:3
 msgid "_Add Account"
 msgstr "_Añadir cuenta"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:242
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:241
 msgid "Preview"
 msgstr "Vista previa"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:302
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:298
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:188
 msgid "More…"
 msgstr "Más…"
 
 #. Translators: a search for input methods or keyboard layouts
 #. * did not yield any results
-#.
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:323
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:319
 msgid "No inputs found"
 msgstr "No se han encontrado fuentes de entrada"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:198
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:190
 msgid "Your keyboard layout seems to be:"
 msgstr "Tu teclado parece ser de formato:"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:313
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:304
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:2
 msgid "Please press one of the following keys:"
 msgstr "Por favor pulsa una de las siguientes teclas:"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:314
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:305
 msgid "Is the following key present on your keyboard?"
 msgstr "Aparece la siguiente tecla en tu teclado?"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:255
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:256
 msgid "Typing"
 msgstr "Escritura"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
-msgid "Select your keyboard layout or an input method."
-msgstr "Seleccione la distribución de su teclado o un método de entrada."
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+msgid "Select your keyboard layout"
+msgstr "Seleccione la distribución de su teclado"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:3
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
 msgid "Help detect my keyboard layout"
 msgstr "Ayuda a detectar el formato de mi teclado"
 
@@ -453,16 +429,16 @@ msgstr "Detecta el formato de mi teclado..."
 msgid "No languages found"
 msgstr "No se encontraron idiomas"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:524
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:531
 msgid "Welcome"
 msgstr "Bienvenido"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:528
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:535
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:2
 msgid "Welcome to Endless!"
 msgstr "¡Bienvenido a Endless!"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:530
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:537
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:3
 msgid "Let's set up your computer..."
 msgstr "Ahora, vamos a configurar tu computadora... "
@@ -471,11 +447,11 @@ msgstr "Ahora, vamos a configurar tu computadora... "
 msgid "Power Off"
 msgstr "Apagar"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:643
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:662
 msgid "Search for a location"
 msgstr "Buscar una ubicación"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:778
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:797
 #: ../gnome-initial-setup/pages/location/gis-location-page.ui.h:15
 msgid "Location"
 msgstr "Ubicación"
@@ -585,22 +561,16 @@ msgstr "Redes inalámbricas"
 msgid ""
 "Do you have wireless internet (WiFi)? If you do, connect your computer to "
 "the internet by clicking on the name of your WiFi network and entering the "
-"network password. This password may be different from your computer password."
-msgstr ""
-"¿Tienes internet inalámbrico (WiFi)? Para conectar tu computadora al "
-"internet, haz clic en el nombre de tu red WiFi y después ingresa la "
-"contraseña de la red. Esta contraseña puede ser diferente a la contraseña "
-"que ingresaste para esta computadora."
+"network password. This password may be different from your computer "
+"password."
+msgstr "¿Tienes internet inalámbrico (WiFi)? Para conectar tu computadora al internet, haz clic en el nombre de tu red WiFi y después ingresa la contraseña de la red. Esta contraseña puede ser diferente a la contraseña que ingresaste para esta computadora."
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:3
 msgid ""
 "TIP: You can use your computer without internet if you do not have a "
-"connection now. If you get an internet connection in the future, you can set "
-"it up in \"Network Settings.\""
-msgstr ""
-"Consejo: Puedes usar tu computadora aunque no tengas internet en este "
-"momento. Si algún día tienes acceso a una conexión, podrás agregar la red en "
-"\"Configuración de red.\""
+"connection now. If you get an internet connection in the future, you can set"
+" it up in \"Network Settings.\""
+msgstr "Consejo: Puedes usar tu computadora aunque no tengas internet en este momento. Si algún día tienes acceso a una conexión, podrás agregar la red en \"Configuración de red.\""
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:4
 msgid "No wireless available"
@@ -610,12 +580,12 @@ msgstr "La red inalámbrica no está disponible"
 msgid "_Skip WiFi setup"
 msgstr "_Configurar más tarde"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:392
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:394
 #, c-format
 msgid "_Start using %s"
 msgstr "_Empezar a usar %s"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:418
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:420
 msgid "Thank You"
 msgstr "Gracias"
 
@@ -630,12 +600,3 @@ msgstr "Puedes cambiar estas opciones en cualquier momento en Configuración."
 #: ../gnome-initial-setup/pages/summary/gis-summary-page.ui.h:3
 msgid "_Start using GNOME 3"
 msgstr "_Empezar a usar GNOME 3"
-
-#~ msgid "Other"
-#~ msgstr "Otra"
-
-#~ msgid "Keyboard Layouts"
-#~ msgstr "Formatos de teclado"
-
-#~ msgid "Add a Keyboard Layout"
-#~ msgstr "Añade otro formato de teclado"

--- a/po/es.po
+++ b/po/es.po
@@ -16,8 +16,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-13 16:12-0700\n"
-"PO-Revision-Date: 2015-03-13 23:18+0000\n"
+"POT-Creation-Date: 2015-03-13 16:30-0700\n"
+"PO-Revision-Date: 2015-03-13 23:37+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/gnome-initial-setup/language/es/)\n"
 "MIME-Version: 1.0\n"
@@ -424,6 +424,10 @@ msgstr "Ayuda a detectar el formato de mi teclado"
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:1
 msgid "Detect Keyboard Layout..."
 msgstr "Detecta el formato de mi teclado..."
+
+#: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:3
+msgid "Select"
+msgstr "Seleccionar"
 
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:205
 msgid "No languages found"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,25 +1,24 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Abner Silva <abner@endlessm.com>, 2014
 # Alexandre Franke <alexandre.franke@gmail.com>, 2012
 # Christophe Fergeau <teuf@gnome.org>, 2013
-# Roddy Shuler <roddy@endlessm.com>, 2014
+# Roddy Shuler <roddy@endlessm.com>, 2014-2015
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 12:37+0100\n"
-"PO-Revision-Date: 2014-12-17 00:35+0000\n"
-"Last-Translator: endlessmobile_build <philip@endlessm.com>\n"
-"Language-Team: French (http://www.transifex.com/projects/p/gnome-initial-"
-"setup/language/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2015-03-13 16:12-0700\n"
+"PO-Revision-Date: 2015-03-13 23:19+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: French (http://www.transifex.com/projects/p/gnome-initial-setup/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: ../data/gnome-initial-setup.desktop.in.in.h:1
@@ -53,27 +52,27 @@ msgid "No password"
 msgstr "Pas de mot de passe"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.c:331
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:436
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:445
 msgid "Passwords do not match"
 msgstr "Les mots de passe ne correspondent pas"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:555
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:564
 msgid "Failed to register account"
 msgstr "Échec lors de l'enregistrement du compte"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:763
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:772
 msgid "No supported way to authenticate with this domain"
 msgstr "Aucune méthode prise en charge pour authentifier avec ce domaine"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:803
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:812
 msgid "Failed to join domain"
 msgstr "Échec lors de la prise de contact avec le domaine"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:871
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:880
 msgid "Failed to log into domain"
 msgstr "Échec lors de la connexion au domaine"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:1296
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:1305
 msgid "Login"
 msgstr "Connexion"
 
@@ -91,12 +90,7 @@ msgid ""
 "upper case letters. If the caps lock key is pressed, the symbol ⚠ will "
 "appear at the right side of the space in which you're writing. You'll need "
 "to type in this password identically each time you access your account."
-msgstr ""
-"Vous voudrez peut-être écrire votre mot de passe. Assurez-vous de faire "
-"attention aux lettres en majuscule. Si vous appuyez sur la touche Majuscule, "
-"le symbole ⚠ apparaît à droite de l'espace où vous écrivez. Vous devrez "
-"saisir ce mot de passe de manière identique à chaque fois que vous accèderez "
-"à votre compte."
+msgstr "Vous voudrez peut-être écrire votre mot de passe. Assurez-vous de faire attention aux lettres en majuscule. Si vous appuyez sur la touche Majuscule, le symbole ⚠ apparaît à droite de l'espace où vous écrivez. Vous devrez saisir ce mot de passe de manière identique à chaque fois que vous accèderez à votre compte."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:4
 msgid "_Full Name"
@@ -110,9 +104,7 @@ msgstr "Nom d'_utilisateur"
 msgid ""
 "The username will be used to name your personal folder, and it cannot be "
 "changed."
-msgstr ""
-"Le nom d'utilisateur sera utilisé pour nommer votre dossier personnel et il "
-"ne peut pas être modifié."
+msgstr "Le nom d'utilisateur sera utilisé pour nommer votre dossier personnel et il ne peut pas être modifié."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:7
 msgid "_Password"
@@ -124,11 +116,9 @@ msgstr "_Confirmer le mot de passe"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:9
 msgid ""
-"To make your password more secure, you can use letters and numbers together. "
-"This is optional."
-msgstr ""
-"Pour rendre votre mot de passe plus sûr, vous pouvez utiliser des lettres et "
-"des chiffres ensemble. Ceci est facultatif."
+"To make your password more secure, you can use letters and numbers together."
+" This is optional."
+msgstr "Pour rendre votre mot de passe plus sûr, vous pouvez utiliser des lettres et des chiffres ensemble. Ceci est facultatif."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:10
 msgid "To continue, please make sure you fill in all the blanks."
@@ -168,11 +158,7 @@ msgid ""
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here, and choose a unique computer\n"
 "name for your computer."
-msgstr ""
-"Afin d'utiliser des connexions d'entreprise, cet ordinateur doit\n"
-"être enregistré dans le domaine. Demandez à votre administrateur de\n"
-"réseau de saisir le mot de passe du domaine, et choisissez un nom\n"
-"d'ordinateur unique pour cet ordinateur."
+msgstr "Afin d'utiliser des connexions d'entreprise, cet ordinateur doit\nêtre enregistré dans le domaine. Demandez à votre administrateur de\nréseau de saisir le mot de passe du domaine, et choisissez un nom\nd'ordinateur unique pour cet ordinateur."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:22
 msgid "_Computer"
@@ -260,11 +246,7 @@ msgid ""
 " ➣ letters from the English alphabet\n"
 " ➣ digits\n"
 " ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"Le nom d'utilisateur doit être uniquement composé de :\n"
-" ➣ lettres de l'alphabet anglais\n"
-" ➣ nombres\n"
-" ➣ caractères parmi « . », « - » et « _ »"
+msgstr "Le nom d'utilisateur doit être uniquement composé de :\n ➣ lettres de l'alphabet anglais\n ➣ nombres\n ➣ caractères parmi « . », « - » et « _ »"
 
 #: ../gnome-initial-setup/pages/display/gis-display-page.c:281
 msgid "Display"
@@ -307,10 +289,7 @@ msgstr "Veuillez lire les conditions d'utilisation avec attention"
 msgid ""
 "By clicking \"Accept and continue,\" you acknowledge that you have read, "
 "understood, and agree to be bound by the following terms and conditions."
-msgstr ""
-"En cliquant sur « accepter et continuer, » vous reconnaissez avoir lu et "
-"compris les présentes conditions d'utilisation et acceptez de vous y "
-"soumettre."
+msgstr "En cliquant sur « accepter et continuer, » vous reconnaissez avoir lu et compris les présentes conditions d'utilisation et acceptez de vous y soumettre."
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:3
 msgid "Help make Endless better for everyone"
@@ -320,10 +299,7 @@ msgstr "Aidez à améliorer Endless pour tous"
 msgid ""
 "Automatically save and send usage statistics and problem reports to Endless "
 "Mobile. All data is anonymous."
-msgstr ""
-"Enregistrez automatiquement vos statistiques d'utilisation et vos rapports "
-"de problèmes et envoyez-les à Endless Mobile. Toutes les données sont "
-"anonymes."
+msgstr "Enregistrez automatiquement vos statistiques d'utilisation et vos rapports de problèmes et envoyez-les à Endless Mobile. Toutes les données sont anonymes."
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1
@@ -334,9 +310,7 @@ msgstr "Contrats de licence"
 msgid ""
 "I have _agreed to the terms and conditions in this end user license "
 "agreement."
-msgstr ""
-"Je suis d'_accord avec les termes et les conditions dans ce contrat de "
-"licence d'utilisateur final."
+msgstr "Je suis d'_accord avec les termes et les conditions dans ce contrat de licence d'utilisateur final."
 
 #: ../gnome-initial-setup/pages/goa/cc-online-accounts-add-account-dialog.c:200
 msgctxt "Online Account"
@@ -396,53 +370,49 @@ msgstr "Connectez vous à vos données existantes dans le nuage"
 msgid ""
 "Adding accounts will allow you to transparently connect to your online "
 "photos, contacts, mail, and more."
-msgstr ""
-"L'ajout de comptes vous permettra de vous connecter de manière transparente "
-"à vos photos, contacts, courriels et autres données en ligne."
+msgstr "L'ajout de comptes vous permettra de vous connecter de manière transparente à vos photos, contacts, courriels et autres données en ligne."
 
 #: ../gnome-initial-setup/pages/goa/gis-goa-page.ui.h:3
 msgid "_Add Account"
 msgstr "_Ajouter un compte"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:242
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:241
 msgid "Preview"
 msgstr "Aperçu"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:302
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:298
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:188
 msgid "More…"
 msgstr "Plus…"
 
 #. Translators: a search for input methods or keyboard layouts
 #. * did not yield any results
-#.
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:323
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:319
 msgid "No inputs found"
 msgstr "Aucune méthode de saisie trouvée"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:198
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:190
 msgid "Your keyboard layout seems to be:"
 msgstr "La disposition de votre clavier semble être :"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:313
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:304
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:2
 msgid "Please press one of the following keys:"
 msgstr "Veuillez appuyer sur l'une des touches suivantes :"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:314
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:305
 msgid "Is the following key present on your keyboard?"
 msgstr "Est-ce que la touche suivante est présente sur votre clavier ?"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:255
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:256
 msgid "Typing"
 msgstr "Saisie"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
-msgid "Select your keyboard layout or an input method."
-msgstr "Choisissez la disposition du clavier ou une méthode de saisie."
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+msgid "Select your keyboard layout"
+msgstr "Choisissez la disposition du clavier"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:3
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
 msgid "Help detect my keyboard layout"
 msgstr "M'aider à détecter la disposition de mon clavier"
 
@@ -454,16 +424,16 @@ msgstr "Détection de la disposition du clavier..."
 msgid "No languages found"
 msgstr "Aucune langue trouvée"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:524
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:531
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:528
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:535
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:2
 msgid "Welcome to Endless!"
 msgstr "Bienvenue sur Endless !"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:530
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:537
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:3
 msgid "Let's set up your computer..."
 msgstr "Configurons votre ordinateur..."
@@ -472,11 +442,11 @@ msgstr "Configurons votre ordinateur..."
 msgid "Power Off"
 msgstr "Eteindre"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:643
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:662
 msgid "Search for a location"
 msgstr "Rechercher un emplacement"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:778
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:797
 #: ../gnome-initial-setup/pages/location/gis-location-page.ui.h:15
 msgid "Location"
 msgstr "Emplacement"
@@ -586,23 +556,16 @@ msgstr "Réseaux sans fils"
 msgid ""
 "Do you have wireless internet (WiFi)? If you do, connect your computer to "
 "the internet by clicking on the name of your WiFi network and entering the "
-"network password. This password may be different from your computer password."
-msgstr ""
-"Disposez-vous d'une connexion à Internet sans fil (Wifi) ? Si c'est le cas, "
-"connectez votre ordinateur à Internet en cliquant sur le nom de votre réseau "
-"et en saisissant son mot de passe. Ce mot de passe peut être différent du "
-"mot de passe de votre ordinateur."
+"network password. This password may be different from your computer "
+"password."
+msgstr "Disposez-vous d'une connexion à Internet sans fil (Wifi) ? Si c'est le cas, connectez votre ordinateur à Internet en cliquant sur le nom de votre réseau et en saisissant son mot de passe. Ce mot de passe peut être différent du mot de passe de votre ordinateur."
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:3
 msgid ""
 "TIP: You can use your computer without internet if you do not have a "
-"connection now. If you get an internet connection in the future, you can set "
-"it up in \"Network Settings.\""
-msgstr ""
-"Astuce : Vous pouvez utiliser votre ordinateur sans Internet si vous ne "
-"disposez pas d'une connexion actuellement. Si vous obtenez une connexion "
-"Internet dans le futur, vous pourrez la configurer dans \"Paramètres réseau."
-"\""
+"connection now. If you get an internet connection in the future, you can set"
+" it up in \"Network Settings.\""
+msgstr "Astuce : Vous pouvez utiliser votre ordinateur sans Internet si vous ne disposez pas d'une connexion actuellement. Si vous obtenez une connexion Internet dans le futur, vous pourrez la configurer dans \"Paramètres réseau.\""
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:4
 msgid "No wireless available"
@@ -612,12 +575,12 @@ msgstr "Aucune connexion sans fil disponible"
 msgid "_Skip WiFi setup"
 msgstr "_Ignorer la configuration Wifi"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:392
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:394
 #, c-format
 msgid "_Start using %s"
 msgstr "_Commencer à utiliser %s"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:418
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:420
 msgid "Thank You"
 msgstr "Merci"
 
@@ -627,19 +590,8 @@ msgstr "Votre ordinateur est prêt à être utilisé."
 
 #: ../gnome-initial-setup/pages/summary/gis-summary-page.ui.h:2
 msgid "You may change these options at any time in Settings."
-msgstr ""
-"Vous pouvez changer ces options quand vous le désirez dans les Paramètres "
-"système"
+msgstr "Vous pouvez changer ces options quand vous le désirez dans les Paramètres système"
 
 #: ../gnome-initial-setup/pages/summary/gis-summary-page.ui.h:3
 msgid "_Start using GNOME 3"
 msgstr "_Commencer à utiliser GNOME 3"
-
-#~ msgid "Other"
-#~ msgstr "Autre"
-
-#~ msgid "Keyboard Layouts"
-#~ msgstr "Dispositions clavier"
-
-#~ msgid "Add a Keyboard Layout"
-#~ msgstr "Ajouter une disposition clavier"

--- a/po/fr.po
+++ b/po/fr.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-13 16:12-0700\n"
-"PO-Revision-Date: 2015-03-13 23:19+0000\n"
+"POT-Creation-Date: 2015-03-13 16:30-0700\n"
+"PO-Revision-Date: 2015-03-13 23:39+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/gnome-initial-setup/language/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -419,6 +419,10 @@ msgstr "M'aider à détecter la disposition de mon clavier"
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:1
 msgid "Detect Keyboard Layout..."
 msgstr "Détection de la disposition du clavier..."
+
+#: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:3
+msgid "Select"
+msgstr "Sélectionner"
 
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:205
 msgid "No languages found"

--- a/po/gnome-initial-setup.pot
+++ b/po/gnome-initial-setup.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 12:37+0100\n"
+"POT-Creation-Date: 2015-03-13 16:12-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,27 +48,27 @@ msgid "No password"
 msgstr ""
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.c:331
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:436
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:445
 msgid "Passwords do not match"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:555
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:564
 msgid "Failed to register account"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:763
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:772
 msgid "No supported way to authenticate with this domain"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:803
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:812
 msgid "Failed to join domain"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:871
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:880
 msgid "Failed to log into domain"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:1296
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:1305
 msgid "Login"
 msgstr ""
 
@@ -372,11 +372,11 @@ msgstr ""
 msgid "_Add Account"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:242
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:241
 msgid "Preview"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:302
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:298
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:188
 msgid "More…"
 msgstr ""
@@ -384,33 +384,32 @@ msgstr ""
 #. Translators: a search for input methods or keyboard layouts
 #. * did not yield any results
 #.
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:323
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:319
 msgid "No inputs found"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:198
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:190
 msgid "Your keyboard layout seems to be:"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:313
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:304
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:2
 msgid "Please press one of the following keys:"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:314
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:305
 msgid "Is the following key present on your keyboard?"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:255
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:256
 msgid "Typing"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
-msgid "Select your keyboard layout or an input method."
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+msgid "Select your keyboard layout"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:3
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
 msgid "Help detect my keyboard layout"
 msgstr ""
 
@@ -422,16 +421,16 @@ msgstr ""
 msgid "No languages found"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:524
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:531
 msgid "Welcome"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:528
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:535
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:2
 msgid "Welcome to Endless!"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:530
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:537
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:3
 msgid "Let's set up your computer..."
 msgstr ""
@@ -440,11 +439,11 @@ msgstr ""
 msgid "Power Off"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:643
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:662
 msgid "Search for a location"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:778
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:797
 #: ../gnome-initial-setup/pages/location/gis-location-page.ui.h:15
 msgid "Location"
 msgstr ""
@@ -572,12 +571,12 @@ msgstr ""
 msgid "_Skip WiFi setup"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:392
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:394
 #, c-format
 msgid "_Start using %s"
 msgstr ""
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:418
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:420
 msgid "Thank You"
 msgstr ""
 

--- a/po/gnome-initial-setup.pot
+++ b/po/gnome-initial-setup.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-13 16:12-0700\n"
+"POT-Creation-Date: 2015-03-13 16:30-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -415,6 +415,10 @@ msgstr ""
 
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:1
 msgid "Detect Keyboard Layout..."
+msgstr ""
+
+#: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:3
+msgid "Select"
 msgstr ""
 
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:205

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-#
+# 
 # Translators:
 # Abner Silva <abner@endlessm.com>, 2014
 # Enrico Nicoletto <liverig@gmail.com>, 2013
@@ -10,21 +10,21 @@
 # Philip Chimento <philip.chimento@gmail.com>, 2014
 # Rafael Ferreira <rafael.f.f1@gmail.com>, 2013
 # Richard Vignais, 2014
-# Roddy Shuler <roddy@endlessm.com>, 2014
+# Richard Vignais, 2014
+# Roddy Shuler <roddy@endlessm.com>, 2014-2015
 # Silva <michele@endlessm.com>, 2014
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-28 12:37+0100\n"
-"PO-Revision-Date: 2014-12-23 10:12+0000\n"
-"Last-Translator: Richard Vignais\n"
-"Language-Team: Portuguese (http://www.transifex.com/projects/p/gnome-initial-"
-"setup/language/pt/)\n"
-"Language: pt\n"
+"POT-Creation-Date: 2015-03-13 16:12-0700\n"
+"PO-Revision-Date: 2015-03-13 23:20+0000\n"
+"Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
+"Language-Team: Portuguese (http://www.transifex.com/projects/p/gnome-initial-setup/language/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../data/gnome-initial-setup.desktop.in.in.h:1
@@ -58,27 +58,27 @@ msgid "No password"
 msgstr "Sem senha"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.c:331
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:436
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:445
 msgid "Passwords do not match"
 msgstr "As senhas não estão iguais"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:555
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:564
 msgid "Failed to register account"
 msgstr "Falha ao registrar a conta"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:763
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:772
 msgid "No supported way to authenticate with this domain"
 msgstr "Nenhuma forma de suporte para autenticar neste domínio"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:803
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:812
 msgid "Failed to join domain"
 msgstr "Ocorreu falha ao ingressar no domínio"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:871
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:880
 msgid "Failed to log into domain"
 msgstr "Ocorreu falha ao iniciar sessão no domínio"
 
-#: ../gnome-initial-setup/pages/account/gis-account-page.c:1296
+#: ../gnome-initial-setup/pages/account/gis-account-page.c:1305
 msgid "Login"
 msgstr "Iniciar sessão"
 
@@ -96,11 +96,7 @@ msgid ""
 "upper case letters. If the caps lock key is pressed, the symbol ⚠ will "
 "appear at the right side of the space in which you're writing. You'll need "
 "to type in this password identically each time you access your account."
-msgstr ""
-"Você pode usar letras para compor a sua senha, mas preste atenção às letras "
-"maiúsculas. Se a tecla Caps Look estiver ativada, o símbolo ⚠ irá aparecer "
-"do lado esquerdo do espaço onde você está digitando a senha. Você terá que "
-"digitar essa senha exatamente igual cada vez que acessar esta conta. "
+msgstr "Você pode usar letras para compor a sua senha, mas preste atenção às letras maiúsculas. Se a tecla Caps Look estiver ativada, o símbolo ⚠ irá aparecer do lado esquerdo do espaço onde você está digitando a senha. Você terá que digitar essa senha exatamente igual cada vez que acessar esta conta. "
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:4
 msgid "_Full Name"
@@ -114,9 +110,7 @@ msgstr "_Nome de usuário"
 msgid ""
 "The username will be used to name your personal folder, and it cannot be "
 "changed."
-msgstr ""
-"O nome de usuário será usado para nomear a sua pasta pessoal e não poderá "
-"ser alterado. "
+msgstr "O nome de usuário será usado para nomear a sua pasta pessoal e não poderá ser alterado. "
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:7
 msgid "_Password"
@@ -128,17 +122,13 @@ msgstr "_Confirmar senha"
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:9
 msgid ""
-"To make your password more secure, you can use letters and numbers together. "
-"This is optional."
-msgstr ""
-"Para tornar sua senha mais segura, você pode usar letras e números juntos. "
-"Isso é opcional. "
+"To make your password more secure, you can use letters and numbers together."
+" This is optional."
+msgstr "Para tornar sua senha mais segura, você pode usar letras e números juntos. Isso é opcional. "
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:10
 msgid "To continue, please make sure you fill in all the blanks."
-msgstr ""
-"Para continuar, por favor, tenha certeza de que todos os espaços em branco "
-"foram preenchidos. "
+msgstr "Para continuar, por favor, tenha certeza de que todos os espaços em branco foram preenchidos. "
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:11
 msgid "Show password"
@@ -174,11 +164,7 @@ msgid ""
 "enrolled in the domain. Please have your network administrator\n"
 "type their domain password here, and choose a unique computer\n"
 "name for your computer."
-msgstr ""
-"Para usar este início de sessão da empresa, este computador\n"
-"precisa estar registrado no domínio. Por favor, solicite que\n"
-"seu administrador digite a senha de domínio aqui e escolha um\n"
-"nome de computador único para seu computador."
+msgstr "Para usar este início de sessão da empresa, este computador\nprecisa estar registrado no domínio. Por favor, solicite que\nseu administrador digite a senha de domínio aqui e escolha um\nnome de computador único para seu computador."
 
 #: ../gnome-initial-setup/pages/account/gis-account-page.ui.h:22
 msgid "_Computer"
@@ -266,11 +252,7 @@ msgid ""
 " ➣ letters from the English alphabet\n"
 " ➣ digits\n"
 " ➣ any of the characters '.', '-' and '_'"
-msgstr ""
-"O nome de usuário deve ser composto apenas por:\n"
-" ➣ letras do alfabeto português\n"
-" ➣ números\n"
-" ➣ qualquer um dos caracteres '.', '-' e '_'"
+msgstr "O nome de usuário deve ser composto apenas por:\n ➣ letras do alfabeto português\n ➣ números\n ➣ qualquer um dos caracteres '.', '-' e '_'"
 
 #: ../gnome-initial-setup/pages/display/gis-display-page.c:281
 msgid "Display"
@@ -313,9 +295,7 @@ msgstr "Por favor, leia os termos de serviço atentamente "
 msgid ""
 "By clicking \"Accept and continue,\" you acknowledge that you have read, "
 "understood, and agree to be bound by the following terms and conditions."
-msgstr ""
-"Ao clicar em \"Aceitar e continuar\", você reconhece haver lido, entendido e "
-"concorda com os seguintes termos e condições. "
+msgstr "Ao clicar em \"Aceitar e continuar\", você reconhece haver lido, entendido e concorda com os seguintes termos e condições. "
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:3
 msgid "Help make Endless better for everyone"
@@ -325,9 +305,7 @@ msgstr "Ajude a criar um Endless melhor para todos"
 msgid ""
 "Automatically save and send usage statistics and problem reports to Endless "
 "Mobile. All data is anonymous."
-msgstr ""
-"Automaticamente salve e envie estatísticas de usabilidade e avisos de "
-"problemas à Endless Mobile. Toda informação é anônima. "
+msgstr "Automaticamente salve e envie estatísticas de usabilidade e avisos de problemas à Endless Mobile. Toda informação é anônima. "
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1
@@ -398,53 +376,49 @@ msgstr "Conectar-se aos seus dados existentes na nuvem"
 msgid ""
 "Adding accounts will allow you to transparently connect to your online "
 "photos, contacts, mail, and more."
-msgstr ""
-"Adicionar contas permite que você conecte-se, de forma transparente, a suas "
-"fotos online, contatos, correio e muito mais."
+msgstr "Adicionar contas permite que você conecte-se, de forma transparente, a suas fotos online, contatos, correio e muito mais."
 
 #: ../gnome-initial-setup/pages/goa/gis-goa-page.ui.h:3
 msgid "_Add Account"
 msgstr "_Adicionar conta"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:242
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:241
 msgid "Preview"
 msgstr "Previsão"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:302
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:298
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:188
 msgid "More…"
 msgstr "Mais…"
 
 #. Translators: a search for input methods or keyboard layouts
 #. * did not yield any results
-#.
-#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:323
+#: ../gnome-initial-setup/pages/keyboard/cc-input-chooser.c:319
 msgid "No inputs found"
 msgstr "Nenhuma entrada encontrada"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:198
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:190
 msgid "Your keyboard layout seems to be:"
 msgstr "Sua configuração de teclado parece ser:"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:313
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:304
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:2
 msgid "Please press one of the following keys:"
 msgstr "Por favor, pressione uma das teclas abaixo:"
 
-#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:314
+#: ../gnome-initial-setup/pages/keyboard/cc-keyboard-query.c:305
 msgid "Is the following key present on your keyboard?"
 msgstr "A seguinte tecla existe no seu teclado?"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:255
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.c:256
 msgid "Typing"
 msgstr "Digitação"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
-msgid "Select your keyboard layout or an input method."
-msgstr "Selecione a disposição de seu teclado ou um método de entrada."
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:1
+msgid "Select your keyboard layout"
+msgstr "Selecione a disposição de seu teclado"
 
-#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:3
+#: ../gnome-initial-setup/pages/keyboard/gis-keyboard-page.ui.h:2
 msgid "Help detect my keyboard layout"
 msgstr "Ajude-me a detectar minha configuração de teclado"
 
@@ -456,16 +430,16 @@ msgstr "Detectar minha configuração de teclado..."
 msgid "No languages found"
 msgstr "Nenhum idioma encontrado"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:524
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:531
 msgid "Welcome"
 msgstr "Bem vindo"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:528
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:535
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:2
 msgid "Welcome to Endless!"
 msgstr "Bem-vindo ao Endless!"
 
-#: ../gnome-initial-setup/pages/language/gis-language-page.c:530
+#: ../gnome-initial-setup/pages/language/gis-language-page.c:537
 #: ../gnome-initial-setup/pages/language/gis-language-page.ui.h:3
 msgid "Let's set up your computer..."
 msgstr "Vamos configurar seu computador... "
@@ -474,11 +448,11 @@ msgstr "Vamos configurar seu computador... "
 msgid "Power Off"
 msgstr "Desligar"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:643
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:662
 msgid "Search for a location"
 msgstr "Pesquisar uma localização"
 
-#: ../gnome-initial-setup/pages/location/gis-location-page.c:778
+#: ../gnome-initial-setup/pages/location/gis-location-page.c:797
 #: ../gnome-initial-setup/pages/location/gis-location-page.ui.h:15
 msgid "Location"
 msgstr "Localização"
@@ -588,22 +562,16 @@ msgstr "Redes sem fio"
 msgid ""
 "Do you have wireless internet (WiFi)? If you do, connect your computer to "
 "the internet by clicking on the name of your WiFi network and entering the "
-"network password. This password may be different from your computer password."
-msgstr ""
-"Você tem internet sem fio (WIFI)? Caso tenha, conecte seu computador à sua "
-"internet clicando no nome da sua rede WIFI e digitando a senha da sua rede. "
-"É possível que a senha da sua rede seja diferente da senha para entrar no "
-"seu computador."
+"network password. This password may be different from your computer "
+"password."
+msgstr "Você tem internet sem fio (WIFI)? Caso tenha, conecte seu computador à sua internet clicando no nome da sua rede WIFI e digitando a senha da sua rede. É possível que a senha da sua rede seja diferente da senha para entrar no seu computador."
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:3
 msgid ""
 "TIP: You can use your computer without internet if you do not have a "
-"connection now. If you get an internet connection in the future, you can set "
-"it up in \"Network Settings.\""
-msgstr ""
-"DICA: Você pode usar seu computador sem internet caso não tenha conexão "
-"agora. Caso tenha acesso a uma conexão de internet no futuro, você pode "
-"conectar-se a ela em \"Definições - Rede\"."
+"connection now. If you get an internet connection in the future, you can set"
+" it up in \"Network Settings.\""
+msgstr "DICA: Você pode usar seu computador sem internet caso não tenha conexão agora. Caso tenha acesso a uma conexão de internet no futuro, você pode conectar-se a ela em \"Definições - Rede\"."
 
 #: ../gnome-initial-setup/pages/network/gis-network-page.ui.h:4
 msgid "No wireless available"
@@ -613,12 +581,12 @@ msgstr "Nenhuma rede sem fio (WIFI) disponível"
 msgid "_Skip WiFi setup"
 msgstr "_Pular configuração de rede sem fio (WIFI)"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:392
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:394
 #, c-format
 msgid "_Start using %s"
 msgstr "_Começar a usar o %s"
 
-#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:418
+#: ../gnome-initial-setup/pages/summary/gis-summary-page.c:420
 msgid "Thank You"
 msgstr "Obrigado"
 
@@ -628,19 +596,8 @@ msgstr "Seu computador está pronto para ser usado."
 
 #: ../gnome-initial-setup/pages/summary/gis-summary-page.ui.h:2
 msgid "You may change these options at any time in Settings."
-msgstr ""
-"Você pode alterar quaisquer destas opções a qualquer momento em "
-"Configurações."
+msgstr "Você pode alterar quaisquer destas opções a qualquer momento em Configurações."
 
 #: ../gnome-initial-setup/pages/summary/gis-summary-page.ui.h:3
 msgid "_Start using GNOME 3"
 msgstr "Começar a usar o _GNOME 3"
-
-#~ msgid "Other"
-#~ msgstr "Outro"
-
-#~ msgid "Keyboard Layouts"
-#~ msgstr "Definições de teclado"
-
-#~ msgid "Add a Keyboard Layout"
-#~ msgstr "Adicionar uma definição de teclado"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -17,8 +17,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-13 16:12-0700\n"
-"PO-Revision-Date: 2015-03-13 23:20+0000\n"
+"POT-Creation-Date: 2015-03-13 16:30-0700\n"
+"PO-Revision-Date: 2015-03-13 23:38+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/projects/p/gnome-initial-setup/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -425,6 +425,10 @@ msgstr "Ajude-me a detectar minha configuração de teclado"
 #: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:1
 msgid "Detect Keyboard Layout..."
 msgstr "Detectar minha configuração de teclado..."
+
+#: ../gnome-initial-setup/pages/keyboard/keyboard-detector.ui.h:3
+msgid "Select"
+msgstr "Selecionar"
 
 #: ../gnome-initial-setup/pages/language/cc-language-chooser.c:205
 msgid "No languages found"


### PR DESCRIPTION
We do not use page icons in other pages, and we loose a valuable space,
specially when running in low resolutions.

[endlessm/eos-shell#3364]