### PR TITLE
Refer to company as Endless

### DIFF
--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
@@ -143,7 +143,7 @@ get_terms_document (void)
                                    "eos-license-service",
                                    "terms",
                                    language,
-                                   "Endless-Mobile-Terms-of-Use.pdf",
+                                   "Endless-Terms-of-Use.pdf",
                                    NULL);
 
           if (g_file_test (path, G_FILE_TEST_EXISTS))

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
@@ -123,7 +123,7 @@
             <property name="can_focus">False</property>
             <property name="valign">start</property>
             <property name="yalign">0</property>
-            <property name="label" translatable="yes">Automatically save and send usage statistics and problem reports to Endless Mobile. All data is anonymous.</property>
+            <property name="label" translatable="yes">Automatically save and send usage statistics and problem reports to Endless. All data is anonymous.</property>
             <property name="use_markup">True</property>
             <property name="wrap">True</property>
             <property name="width_chars">48</property>

--- a/po/ar.po
+++ b/po/ar.po
@@ -294,9 +294,9 @@ msgstr "المساعدة في تحسين Endless لمصلحة الجميع"
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:4
 msgid ""
-"Automatically save and send usage statistics and problem reports to Endless "
-"Mobile. All data is anonymous."
-msgstr "تخزين وإرسال تلقائي لإحصائيات الاستخدام وتقارير المشاكل إلى موبايل Endless. يتم التعامل مع كافة البيانات بدون الكشف عن هوية الشخص المرسل."
+"Automatically save and send usage statistics and problem reports to Endless. "
+"All data is anonymous."
+msgstr "تخزين وإرسال تلقائي لإحصائيات الاستخدام وتقارير المشاكل إلى Endless. يتم التعامل مع كافة البيانات بدون الكشف عن هوية الشخص المرسل."
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1

--- a/po/es.po
+++ b/po/es.po
@@ -301,9 +301,9 @@ msgstr "Ayuda a hacer Endless mejor para todos"
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:4
 msgid ""
-"Automatically save and send usage statistics and problem reports to Endless "
-"Mobile. All data is anonymous."
-msgstr "Automáticamente guarda y envía estadísticas de uso e informes de problemas a Endless Mobile. Toda la información mandada es anónima."
+"Automatically save and send usage statistics and problem reports to Endless. "
+"All data is anonymous."
+msgstr "Automáticamente guarda y envía estadísticas de uso e informes de problemas a Endless. Toda la información mandada es anónima."
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1

--- a/po/fr.po
+++ b/po/fr.po
@@ -296,9 +296,9 @@ msgstr "Aidez à améliorer Endless pour tous"
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:4
 msgid ""
-"Automatically save and send usage statistics and problem reports to Endless "
-"Mobile. All data is anonymous."
-msgstr "Enregistrez automatiquement vos statistiques d'utilisation et vos rapports de problèmes et envoyez-les à Endless Mobile. Toutes les données sont anonymes."
+"Automatically save and send usage statistics and problem reports to Endless. "
+"All data is anonymous."
+msgstr "Enregistrez automatiquement vos statistiques d'utilisation et vos rapports de problèmes et envoyez-les à Endless. Toutes les données sont anonymes."
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1

--- a/po/gnome-initial-setup.pot
+++ b/po/gnome-initial-setup.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-19 07:07+0000\n"
+"POT-Creation-Date: 2015-03-20 22:27-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -292,8 +292,8 @@ msgstr ""
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:4
 msgid ""
-"Automatically save and send usage statistics and problem reports to Endless "
-"Mobile. All data is anonymous."
+"Automatically save and send usage statistics and problem reports to Endless. "
+"All data is anonymous."
 msgstr ""
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -302,9 +302,9 @@ msgstr "Ajude a criar um Endless melhor para todos"
 
 #: ../gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui.h:4
 msgid ""
-"Automatically save and send usage statistics and problem reports to Endless "
-"Mobile. All data is anonymous."
-msgstr "Automaticamente salve e envie estatísticas de usabilidade e avisos de problemas à Endless Mobile. Toda informação é anônima. "
+"Automatically save and send usage statistics and problem reports to Endless. "
+"All data is anonymous."
+msgstr "Automaticamente salve e envie estatísticas de usabilidade e avisos de problemas à Endless. Toda informação é anônima. "
 
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.c:324
 #: ../gnome-initial-setup/pages/eulas/gis-eula-page.ui.h:1


### PR DESCRIPTION
Other than formal references to the full company name
(Endless Mobile, Inc.), we will simply use the name Endless
(rather than Endless Mobile).

[endlessm/eos-shell#4791]