### PR TITLE
Add basic SD card detection to factory dialog

### DIFF
--- a/gnome-initial-setup/pages/language/Makefile.am
+++ b/gnome-initial-setup/pages/language/Makefile.am
@@ -6,7 +6,8 @@ AM_CPPFLAGS = \
 	-I"$(top_srcdir)/gnome-initial-setup" \
 	-I"$(top_builddir)" \
 	-DDATADIR=\""$(datadir)"\" \
-	-DGNOMELOCALEDIR=\""$(datadir)/locale"\"
+	-DGNOMELOCALEDIR=\""$(datadir)/locale"\" \
+	-DLOCALSTATEDIR=\""$(localstatedir)"\"
 
 BUILT_SOURCES =
 

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -301,6 +301,22 @@ get_serial_version (gchar **display_serial,
   return TRUE;
 }
 
+static gboolean
+get_have_sdcard (void)
+{
+  GDir *dir;
+  gboolean has_bundles;
+
+  dir = g_dir_open (LOCALSTATEDIR "/endless-extra", 0, NULL);
+  if (!dir)
+    return FALSE;
+
+  has_bundles = (g_dir_read_name (dir) != NULL);
+  g_dir_close (dir);
+
+  return has_bundles;
+}
+
 static gchar *
 get_software_version (void)
 {
@@ -422,6 +438,7 @@ show_factory_dialog (GisLanguagePage *page)
   GtkDialog *factory_dialog;
   GtkImage *serial_image;
   GtkLabel *personality_label;
+  GtkLabel *sdcard_label;
   GtkLabel *serial_label;
   GtkLabel *version_label;
   gboolean have_serial;
@@ -432,6 +449,7 @@ show_factory_dialog (GisLanguagePage *page)
   factory_dialog = OBJ (GtkDialog *, "factory-dialog");
   version_label = OBJ (GtkLabel *, "software-version");
   personality_label = OBJ (GtkLabel *, "personality");
+  sdcard_label = OBJ (GtkLabel *, "sd-card");
   serial_label = OBJ (GtkLabel *, "serial-text");
   serial_image = OBJ (GtkImage *, "serial-barcode");
   poweroff_button = OBJ (GtkButton *, "poweroff-button");
@@ -452,6 +470,12 @@ show_factory_dialog (GisLanguagePage *page)
   } else {
     gtk_widget_set_visible (GTK_WIDGET (serial_label), FALSE);
     gtk_widget_set_visible (GTK_WIDGET (serial_image), FALSE);
+  }
+
+  if (get_have_sdcard ()) {
+    gtk_label_set_text (sdcard_label, _("SD Card: Enabled"));
+  } else {
+    gtk_label_set_text (sdcard_label, _("SD Card: Disabled"));
   }
 
   g_signal_connect_swapped (poweroff_button, "clicked",

--- a/gnome-initial-setup/pages/language/gis-language-page.ui
+++ b/gnome-initial-setup/pages/language/gis-language-page.ui
@@ -89,6 +89,22 @@
                 <property name="position">1</property>
               </packing>
             </child>
+	    <child>
+              <object class="GtkLabel" id="sd-card">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">sd card</property>
+                <attributes>
+                  <attribute name="font-desc" value="&lt;Enter Value&gt; 20"/>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkImage" id="serial-barcode">
                 <property name="visible">True</property>
@@ -99,7 +115,7 @@
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="padding">16</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -115,7 +131,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
We just check whether there's a directory at /var/endless-extra and that
it's not empty.

[endlessm/eos-shell#4991]