### PR TITLE
Factory dialog: Show SD card version info

### DIFF
--- a/gnome-initial-setup/pages/language/gis-language-page.ui
+++ b/gnome-initial-setup/pages/language/gis-language-page.ui
@@ -95,7 +95,7 @@
                 <property name="can_focus">False</property>
                 <property name="label">sd card</property>
                 <attributes>
-                  <attribute name="font-desc" value="&lt;Enter Value&gt; 20"/>
+                  <attribute name="font-desc" value="&lt;Enter Value&gt; 16"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>


### PR DESCRIPTION
Requested for factory processes, so that the operator can verify that
the right image version and country was flashed on the SD card.

[endlessm/eos-shell#4997]