### PR TITLE
build: bump webkit dependency version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ PKG_CHECK_MODULES(INITIAL_SETUP,
                   libsecret-1
                   evince-view-3.0
                   evince-document-3.0
-                  webkit2gtk-3.0)
+                  webkit2gtk-4.0)
 
 PKG_CHECK_MODULES(COPY_WORKER, gio-2.0 gnome-keyring-1)
 


### PR DESCRIPTION
Depend on webkit2gtk-4.0 instead of webkit2gtk-3.0.

[endlessm/eos-shell#5202]