### PR TITLE
Do not depend on libwebkit2gtk-3.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Build-Depends: cdbs (>= 0.4.41),
 	       valac,
 	       zint-devel,
 	       libevince-dev,
-	       libwebkit2gtk-3.0-dev
+	       libwebkit2gtk-4.0-dev
 Standards-Version: 3.9.4
 Homepage: https://git.gnome.org/browse/gnome-initial-setup/
 


### PR DESCRIPTION
Depend on libwebkit2gtk-4.0 instead.

[endlessm/eos-shell#5202-debian]