### PR TITLE
setup-shell: Make sure that the shell launches first

### DIFF
--- a/data/setup-shell.desktop
+++ b/data/setup-shell.desktop
@@ -3,3 +3,6 @@ Type=Application
 Name=GNOME Shell
 Exec=gnome-shell --mode=initial-setup
 X-GNOME-AutoRestart=true
+X-GNOME-Autostart-Phase=WindowManager
+X-GNOME-Provides=panel;windowmanager;
+X-GNOME-Autostart-Notify=true


### PR DESCRIPTION
On systems where the shell might be slow to start up, we need to make
sure gnome-initial-setup launches after the WM has time to initialize.

Copy these lines from gnome-shell's desktop file to get our setup shell
spawned at the right phase.

https://github.com/endlessm/eos-shell/issues/4669