### PR TITLE
Use upstream 'overlay' filesystem

### DIFF
--- a/gnome-initial-setup/pages/language/eos-test-mode
+++ b/gnome-initial-setup/pages/language/eos-test-mode
@@ -39,8 +39,9 @@ for dir in $overlay_dirs; do
     # If the directory is a symlink, assume it's pointing to a location
     # covered by another top level overlay
     [ -L /$dir ] && continue
-    mkdir -p /run/eos-test/$dir
-    mount -t overlayfs -o rw,upperdir=/run/eos-test/$dir,lowerdir=/$dir \
+    mkdir -p /run/eos-test/$dir /run/eos-test/$dir-workdir
+    mount -t overlay -o \
+        rw,upperdir=/run/eos-test/$dir,lowerdir=/$dir,workdir=/run/eos-test/$dir-workdir \
         eos-test-$dir /$dir
 done
 


### PR DESCRIPTION
Ubuntu's Linux 4.1 (a requirement for eos 2.4.0) does not provide the
'overlayfs' filesystem we have been using before the upgrade, but a
compatibility layer implemented on top of the upstream 'overlay'
filesystem (endlessm/linux@a61b539). Since we're moving to a new
codebase in any case, let's just use the upstream version directly.

For both 'overlay' and 'overlayfs' filesystems there is a 'workdir'
mount option that needs to be passed to rw mounts.

[endlessm/eos-shell#4518]