### PR TITLE
This reorders the macros so that AC_USE_SYSTEM_EXTENSIONS comes after

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,13 @@
 AC_INIT([gnome-initial-setup],[3.10.1.1])
 AC_CONFIG_MACRO_DIR([m4])
-AC_USE_SYSTEM_EXTENSIONS
+
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign tar-ustar])
 AM_SILENT_RULES([yes])
-LT_INIT
+
+AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CC
+
+LT_INIT
 
 IT_PROG_INTLTOOL([0.40])
 


### PR DESCRIPTION
initializing automake. Without this, $install_sh doesn't get expanded
properly, causing errors like:

/bin/sh: /home/kalev/install-sh: No such file or directory
install: cannot create regular file ‘/media/build/gnome/_jhbuild/root-gnome-initial-setup/media/build/gnome/share/locale/af/LC_MESSAGES/gnome-initial-setup.mo’: No such file or directory

Related: https://bugs.freedesktop.org/show_bug.cgi?id=66413

[endlessm/eos-shell#5434]