### PR TITLE
Fix crashes when no keyboard layout selected

### DIFF
--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -136,14 +136,14 @@ get_layout (CcInputChooser *chooser,
 {
         CcInputChooserPrivate *priv = cc_input_chooser_get_instance_private (chooser);
 
-	if (g_str_equal (type, INPUT_SOURCE_TYPE_XKB)) {
+	if (g_strcmp0 (type, INPUT_SOURCE_TYPE_XKB) == 0) {
 		gnome_xkb_info_get_layout_info (priv->xkb_info,
 						id, NULL, NULL,
 						layout, variant);
                 return TRUE;
         }
 #ifdef HAVE_IBUS
-	if (g_str_equal (type, INPUT_SOURCE_TYPE_IBUS)) {
+	if (g_strcmp0 (type, INPUT_SOURCE_TYPE_IBUS) == 0) {
                 IBusEngineDesc *engine_desc = NULL;
 
 		if (priv->ibus_engines)
@@ -157,7 +157,6 @@ get_layout (CcInputChooser *chooser,
                 return TRUE;
 	}
 #endif
-        g_assert_not_reached ();
 	return FALSE;
 }
 
@@ -273,7 +272,7 @@ sync_checkmark (GtkWidget *row,
 	if (priv->id == NULL || priv->type == NULL)
 		should_be_visible = FALSE;
 	else
-	        should_be_visible = g_str_equal (widget->id, priv->id) && g_str_equal (widget->type, priv->type);
+	        should_be_visible = g_strcmp0 (widget->id, priv->id) == 0 && g_strcmp0 (widget->type, priv->type) == 0;
         gtk_widget_set_opacity (widget->checkmark, should_be_visible ? 1.0 : 0.0);
 }
 

--- a/gnome-initial-setup/pages/keyboard/gis-keyboard-page.c
+++ b/gnome-initial-setup/pages/keyboard/gis-keyboard-page.c
@@ -212,6 +212,23 @@ show_keyboard_detector (CcInputChooser  *chooser,
 }
 
 static void
+update_page_complete (GisKeyboardPage *self)
+{
+        GisKeyboardPagePrivate *priv = gis_keyboard_page_get_instance_private (self);
+        gboolean complete;
+
+        complete = cc_input_chooser_get_input_id (CC_INPUT_CHOOSER (priv->input_chooser)) != NULL;
+        gis_page_set_complete (GIS_PAGE (self), complete);
+}
+
+static void
+input_changed (CcInputChooser  *chooser,
+               GisKeyboardPage *self)
+{
+        update_page_complete (self);
+}
+
+static void
 gis_keyboard_page_constructed (GObject *object)
 {
         GisKeyboardPage *self = GIS_KEYBOARD_PAGE (object);
@@ -223,6 +240,8 @@ gis_keyboard_page_constructed (GObject *object)
 
         g_signal_connect (priv->input_chooser, "confirm",
                           G_CALLBACK (input_confirmed), self);
+        g_signal_connect (priv->input_chooser, "changed",
+                          G_CALLBACK (input_changed), self);
 
         g_signal_connect (priv->input_auto_detect, "clicked",
                           G_CALLBACK (show_keyboard_detector), self);
@@ -246,7 +265,8 @@ gis_keyboard_page_constructed (GObject *object)
 	if (gis_driver_get_mode (GIS_PAGE (self)->driver) == GIS_DRIVER_MODE_NEW_USER)
 		priv->permission = polkit_permission_new_sync ("org.freedesktop.locale1.set-keyboard", NULL, NULL, NULL);
 
-        gis_page_set_complete (GIS_PAGE (self), TRUE);
+        update_page_complete (self);
+
         gtk_widget_show (GTK_WIDGET (self));
 }
 


### PR DESCRIPTION
Patches cherry picked from upstream (https://bugzilla.gnome.org/show_bug.cgi?id=737493)

[endlessm/eos-shell#5543]