### PR TITLE
Fix crashes when changing locales while Wifi connectivity is unavailable

### DIFF
--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -352,10 +352,8 @@ refresh_again (gpointer user_data)
   GisNetworkPage *page = GIS_NETWORK_PAGE (user_data);
   GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
 
-  priv->refresh_timeout_id = 0;
-
   refresh_wireless_list (page);
-  return FALSE;
+  return G_SOURCE_REMOVE;
 }
 
 static void
@@ -396,6 +394,12 @@ refresh_wireless_list (GisNetworkPage *page)
   GtkWidget *list;
 
   priv->refreshing = TRUE;
+
+  if (priv->refresh_timeout_id != 0)
+    {
+      g_source_remove (priv->refresh_timeout_id);
+      priv->refresh_timeout_id = 0;
+    }
 
   if (NM_IS_DEVICE_WIFI (priv->nm_device)) {
     state = nm_device_get_state (priv->nm_device);

--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -350,8 +350,6 @@ static gboolean
 refresh_again (gpointer user_data)
 {
   GisNetworkPage *page = GIS_NETWORK_PAGE (user_data);
-  GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
-
   refresh_wireless_list (page);
   return G_SOURCE_REMOVE;
 }


### PR DESCRIPTION
This happens because, in this situation, the network page can be destroyed (automatically, due to the language change) before the GSource callback for `refresh_again()`, installed on a timeout, had been called, causing that callback to access an invalid instance of GisNetworkPage, resulting in a crash.

[endlessm/eos-shell#5438]