### PR TITLE
Don't use language and timezone defaults from personality file

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -37,7 +37,6 @@
 #define PERSONALITY_CONFIG_GROUP "Personality"
 #define SETUP_CONFIG_GROUP "Setup"
 #define PERSONALITY_KEY "PersonalityName"
-#define LANGUAGE_KEY "DefaultLanguage"
 #define TIMEZONE_KEY "DefaultTimezone"
 
 /* Statically include this for now. Maybe later
@@ -82,7 +81,6 @@ struct _GisDriverPrivate {
 
   gchar *personality;
   gchar *lang_id;
-  gchar *lang_override;
   gchar *default_timezone;
 
   GisDriverMode mode;
@@ -99,7 +97,6 @@ gis_driver_finalize (GObject *object)
 
   g_free (priv->personality);
   g_free (priv->lang_id);
-  g_free (priv->lang_override);
   g_free (priv->default_timezone);
 
   G_OBJECT_CLASS (gis_driver_parent_class)->finalize (object);
@@ -197,13 +194,6 @@ gis_driver_get_mode (GisDriver *driver)
 }
 
 const gchar *
-gis_driver_get_language_override (GisDriver *driver)
-{
-  GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
-  return priv->lang_override;  
-}
-
-const gchar *
 gis_driver_get_personality (GisDriver *driver)
 {
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
@@ -272,27 +262,17 @@ gis_driver_read_personality_file (GisDriver *driver)
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
   GKeyFile *keyfile = g_key_file_new ();
   gchar *personality = NULL;
-  gchar *language = NULL;
   gchar *timezone = NULL;
 
   if (g_key_file_load_from_file (keyfile, PERSONALITY_FILE_PATH,
                                  G_KEY_FILE_NONE, NULL)) {
     personality = g_key_file_get_string (keyfile, PERSONALITY_CONFIG_GROUP,
                                          PERSONALITY_KEY, NULL);
-    language = g_key_file_get_string (keyfile, SETUP_CONFIG_GROUP,
-                                      LANGUAGE_KEY, NULL);
     timezone = g_key_file_get_string (keyfile, SETUP_CONFIG_GROUP,
                                       TIMEZONE_KEY, NULL);
   }
 
   priv->personality = personality;
-
-  g_free (priv->lang_override);
-  priv->lang_override = language;
-  if (language) {
-    setlocale (LC_MESSAGES, language);
-    setlocale (LC_TIME, language);
-  }
 
   g_free (priv->default_timezone);
   priv->default_timezone = timezone;

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -35,9 +35,7 @@
 
 #define PERSONALITY_FILE_PATH "/etc/EndlessOS/personality.conf"
 #define PERSONALITY_CONFIG_GROUP "Personality"
-#define SETUP_CONFIG_GROUP "Setup"
 #define PERSONALITY_KEY "PersonalityName"
-#define TIMEZONE_KEY "DefaultTimezone"
 
 /* Statically include this for now. Maybe later
  * we'll generate this from glib-mkenums. */
@@ -81,7 +79,6 @@ struct _GisDriverPrivate {
 
   gchar *personality;
   gchar *lang_id;
-  gchar *default_timezone;
 
   GisDriverMode mode;
 };
@@ -97,7 +94,6 @@ gis_driver_finalize (GObject *object)
 
   g_free (priv->personality);
   g_free (priv->lang_id);
-  g_free (priv->default_timezone);
 
   G_OBJECT_CLASS (gis_driver_parent_class)->finalize (object);
 }
@@ -200,13 +196,6 @@ gis_driver_get_personality (GisDriver *driver)
   return priv->personality;
 }
 
-const gchar *
-gis_driver_get_default_timezone (GisDriver *driver)
-{
-  GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
-  return priv->default_timezone;
-}
-
 static void
 gis_driver_get_property (GObject      *object,
                          guint         prop_id,
@@ -262,20 +251,12 @@ gis_driver_read_personality_file (GisDriver *driver)
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
   GKeyFile *keyfile = g_key_file_new ();
   gchar *personality = NULL;
-  gchar *timezone = NULL;
 
   if (g_key_file_load_from_file (keyfile, PERSONALITY_FILE_PATH,
-                                 G_KEY_FILE_NONE, NULL)) {
+                                 G_KEY_FILE_NONE, NULL))
     personality = g_key_file_get_string (keyfile, PERSONALITY_CONFIG_GROUP,
                                          PERSONALITY_KEY, NULL);
-    timezone = g_key_file_get_string (keyfile, SETUP_CONFIG_GROUP,
-                                      TIMEZONE_KEY, NULL);
-  }
-
   priv->personality = personality;
-
-  g_free (priv->default_timezone);
-  priv->default_timezone = timezone;
 
   g_key_file_free (keyfile);
 }

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -76,8 +76,6 @@ void gis_driver_set_user_language (GisDriver   *driver,
 
 const gchar *gis_driver_get_user_language (GisDriver   *driver);
 
-const gchar *gis_driver_get_language_override (GisDriver *driver);
-
 const gchar *gis_driver_get_personality (GisDriver *driver);
 
 const gchar *gis_driver_get_default_timezone (GisDriver *driver);

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -78,8 +78,6 @@ const gchar *gis_driver_get_user_language (GisDriver   *driver);
 
 const gchar *gis_driver_get_personality (GisDriver *driver);
 
-const gchar *gis_driver_get_default_timezone (GisDriver *driver);
-
 GisDriverMode gis_driver_get_mode (GisDriver *driver);
 
 void gis_driver_add_page (GisDriver *driver,

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -141,6 +141,7 @@ set_language (GisLanguagePage *page)
 
   /* gis spawns processes that also need to be localised */
   g_setenv ("LC_MESSAGES", priv->new_locale_id, TRUE);
+  g_setenv ("LC_TIME", priv->new_locale_id, TRUE);
 
   if (gis_driver_get_mode (driver) == GIS_DRIVER_MODE_NEW_USER) {
       if (g_permission_get_allowed (priv->permission)) {

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -604,7 +604,6 @@ gis_language_page_constructed (GObject *object)
   GisLanguagePagePrivate *priv = gis_language_page_get_instance_private (page);
   GisDriver *driver = GIS_PAGE (page)->driver;
   GClosure *closure;
-  const gchar *lang_override;
 
   g_type_ensure (CC_TYPE_LANGUAGE_CHOOSER);
 
@@ -616,11 +615,6 @@ gis_language_page_constructed (GObject *object)
   gtk_container_add (GTK_CONTAINER (page), WID ("language-page"));
 
   priv->language_chooser = WID ("language-chooser");
-
-  /* Set initial language override */
-  lang_override = gis_driver_get_language_override (driver);
-  if (lang_override)
-    cc_language_chooser_set_language (CC_LANGUAGE_CHOOSER (priv->language_chooser), lang_override);
 
   /* Now connect to language chooser changes */
   g_signal_connect (priv->language_chooser, "notify::language",

--- a/gnome-initial-setup/pages/location/gis-location-page.c
+++ b/gnome-initial-setup/pages/location/gis-location-page.c
@@ -673,16 +673,9 @@ gis_location_page_constructed (GObject *object)
   timezone = timedate1_get_timezone (priv->dtm);
 
   if (!cc_timezone_map_set_timezone (priv->map, timezone)) {
-    GisDriver *driver = GIS_PAGE (page)->driver;
-    const gchar *default_timezone = gis_driver_get_default_timezone (driver);
-
-    if (default_timezone == NULL || default_timezone[0] == '\0') {
-      default_timezone = DEFAULT_TZ;
-    }
-
     g_warning ("Timezone '%s' is unhandled, setting %s as default",
-               timezone, default_timezone);
-    cc_timezone_map_set_timezone (priv->map, default_timezone);
+               timezone, DEFAULT_TZ);
+    cc_timezone_map_set_timezone (priv->map, DEFAULT_TZ);
 
     priv->current_location = cc_timezone_map_get_location (priv->map);
     queue_set_timezone (page);


### PR DESCRIPTION
The image builder now sets the system defaults, so there's no need to read them from the personality file.

[endlessm/eos-shell#4652]