### PR TITLE
Don't run first boot experience for new user accounts

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -56,9 +56,9 @@ CLEANFILES =						\
 	$(NULL)
 
 autostartdir = $(sysconfdir)/xdg/autostart
+# Endless does not install gnome-initial-setup-first-login.desktop
 autostart_DATA =					\
 	gnome-initial-setup-copy-worker.desktop		\
-	gnome-initial-setup-first-login.desktop		\
 	$(NULL)
 
 tmpfilesdir = $(libdir)/tmpfiles.d


### PR DESCRIPTION
Run FBE only for the very first user account on the system, the first
time the system boots, and never for new user accounts.

[endlessm/eos-shell#3727]