### PR TITLE
test-mode: Update /endless handling with symlink farm

### DIFF
--- a/gnome-initial-setup/pages/language/eos-test-mode
+++ b/gnome-initial-setup/pages/language/eos-test-mode
@@ -17,23 +17,16 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# The /endless overlay setup needs to be unmounted before adding the
-# overlays below for 2 reasons.
-#  1. The /var overlay will mask the real SD card mount at
-#     /var/endless-extra.
-#  2. The /endless overlay will maintain connections to the real /var
-#     unless it's unmounted first. A mount -o remount does not work.
+# The /var/endless-extra SD card filesystem needs to be unmounted before
+# adding the overlays below since the /var overlay will mask it.
 extra_unit="var-endless\x2dextra.mount"
-endless_unit=endless.mount
 systemctl -q is-active "$extra_unit" && extra_active=true || extra_active=false
-systemctl -q is-active "$endless_unit" && endless_active=true || endless_active=false
 
-# Unmount the /endless overlay and SD card
-$endless_active && systemctl stop "$endless_unit"
+# Unmount the SD card
 $extra_active && systemctl stop "$extra_unit"
 
 # Mount overlays over any directory that might be written to
-overlay_dirs="bin boot etc home lib opt ostree root sbin srv sysroot var"
+overlay_dirs="bin boot endless etc home lib opt ostree root sbin srv sysroot var"
 for dir in $overlay_dirs; do
     [ -d /$dir ] || continue
     # If the directory is a symlink, assume it's pointing to a location
@@ -45,9 +38,14 @@ for dir in $overlay_dirs; do
         eos-test-$dir /$dir
 done
 
-# Remount the SD card and /endless overlay
-$extra_active && systemctl start "$extra_unit"
-$endless_active && systemctl start "$endless_unit"
+# Remount the SD card and mount a scratch overlay over it
+if $extra_active; then
+    systemctl start "$extra_unit"
+    mkdir -p /run/eos-test/endless-extra /run/eos-test/endless-extra-workdir
+    mount -t overlay -o \
+        rw,upperdir=/run/eos-test/endless-extra,lowerdir=/var/endless-extra,workdir=/run/eos-test/endless-extra-workdir \
+        eos-test-endless-extra /var/endless-extra
+fi
 
 # Disable the updater for this boot
 systemctl stop eos-updater.timer


### PR DESCRIPTION
Our usage of /endless and /var/endless-extra has changed some since the
test-mode script was first created.

  * /endless is no longer an overlayfs but a symlink farm
  * /var/endless-extra is no longer mounted read only

This requires overlays to be mounted over /endless and
/var/endless-extra so that app installation activity is not persistent.
The toplevel /endless directory can be easily handled with the existing
loop. /var/endless-extra needs some additional special handling since
/var is also a scratch overlay. It needs to be unmounted and remounted
around the /var overlay mount, and then an overlay needs to be mounted
on /var/endless-extra.

[endlessm/eos-shell#6152]