### PR TITLE
issue/5924

### DIFF
--- a/gnome-initial-setup/pages/network/gis-network-page.ui
+++ b/gnome-initial-setup/pages/network/gis-network-page.ui
@@ -64,6 +64,7 @@
         <property name="xalign">0</property>
         <property name="yalign">0</property>
         <property name="margin-bottom">18</property>
+        <property name="max_width_chars">75</property>
         <attributes>
           <attribute name="scale" value="0.8"/>
         </attributes>


### PR DESCRIPTION
The "Tip: [...]" label is too big to
fit the screen, and overgrows the window
width.

Fix that by adjusting the maximum width
characters of it.

[endlessm/eos-shell#5924]