### PR TITLE
input-chooser: don't access priv pointer before checking no error

### DIFF
--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -621,18 +621,21 @@ fetch_ibus_engines_result (GObject       *object,
                            GAsyncResult  *result,
                            CcInputChooser *chooser)
 {
-        CcInputChooserPrivate *priv = cc_input_chooser_get_instance_private (chooser);
+        CcInputChooserPrivate *priv;
         GList *list, *l;
         GError *error;
 
         error = NULL;
-        list = ibus_bus_list_engines_async_finish (priv->ibus, result, &error);
-        g_clear_object (&priv->ibus_cancellable);
+        list = ibus_bus_list_engines_async_finish (IBUS_BUS (object), result, &error);
         if (!list && error) {
-                g_warning ("Couldn't finish IBus request: %s", error->message);
+                if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+                        g_warning ("Couldn't finish IBus request: %s", error->message);
                 g_error_free (error);
                 return;
         }
+
+        priv = cc_input_chooser_get_instance_private (chooser);
+        g_clear_object (&priv->ibus_cancellable);
 
         /* Maps engine ids to engine description objects */
         priv->ibus_engines = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_object_unref);


### PR DESCRIPTION
If the GCancellable is cancelled by the finalize() function, the
callback will still be called potentially with an instance of the
CcInputChooser that's not valid anymore.
To avoid crashing in that case, only access the priv pointer of
CcInputChooser when we have no error.

[endlessm/eos-shell#6362]