### PR TITLE
Add zh to LINGUAS

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -57,6 +57,7 @@ th
 tr
 uk
 vi
+zh
 zh_CN
 zh_HK
 zh_TW


### PR DESCRIPTION
Fixes the missing symlink that was intended to provide the zh_CN
fallback translations for missing strings in zh_TW and zh_HK.

[endlessm/eos-shell#6381]