### PR TITLE
Factory dialog: show device-tree compatible string

### DIFF
--- a/gnome-initial-setup/pages/language/gis-language-page.ui
+++ b/gnome-initial-setup/pages/language/gis-language-page.ui
@@ -96,6 +96,20 @@
                 <property name="position">0</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel" id="product-id">
+                <property name="visible">False</property>
+                <property name="can_focus">False</property>
+                <attributes>
+                  <attribute name="font-desc" value="default 16"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
 	    <child>
               <object class="GtkLabel" id="personality">
                 <property name="visible">True</property>
@@ -109,7 +123,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
 	    <child>
@@ -125,7 +139,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -138,7 +152,7 @@
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="padding">16</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child>
@@ -154,7 +168,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">5</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
Useful on ARM, where the value of this string can be used to verify
that the right device tree is being used.

https://phabricator.endlessm.com/T11017