### PR TITLE
T11112

### DIFF
--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -359,9 +359,7 @@ refresh_without_device (GisNetworkPage *page)
 {
   GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
   GtkWidget *label;
-  GtkWidget *swin;
 
-  swin = WID("network-scrolledwindow");
   label = WID("no-network-label");
 
   if (nm_client_get_state (priv->nm_client) == NM_STATE_CONNECTED_GLOBAL)
@@ -370,9 +368,6 @@ refresh_without_device (GisNetworkPage *page)
     gtk_label_set_text (GTK_LABEL (label), _("Network is not available."));
   else
     gtk_label_set_text (GTK_LABEL (label), _("No network devices found."));
-
-  gtk_widget_hide (swin);
-  gtk_widget_show (label);
 }
 
 static void
@@ -387,7 +382,6 @@ refresh_wireless_list (GisNetworkPage *page)
   gboolean disable_skip = FALSE;
   guint i;
   GtkWidget *label;
-  GtkWidget *swin;
   GList *children, *l;
   GtkWidget *list;
 
@@ -431,7 +425,6 @@ refresh_wireless_list (GisNetworkPage *page)
     }
   }
 
-  swin = WID("network-scrolledwindow");
   label = WID("no-network-label");
 
   if (state == NM_DEVICE_STATE_UNMANAGED ||
@@ -441,15 +434,9 @@ refresh_wireless_list (GisNetworkPage *page)
   }
   else if (aps == NULL || aps->len == 0) {
     gtk_label_set_text (GTK_LABEL (label), _("Checking for available wireless networks"));
-    gtk_widget_hide (swin);
-    gtk_widget_show (label);
     priv->refresh_timeout_id = g_timeout_add_seconds (1, refresh_again, page);
 
     goto out;
-  }
-  else {
-    gtk_widget_show (swin);
-    gtk_widget_hide (label);
   }
 
   unique_aps = get_strongest_unique_aps (aps);
@@ -669,6 +656,7 @@ gis_network_page_constructed (GObject *object)
   gtk_list_box_set_selection_mode (GTK_LIST_BOX (box), GTK_SELECTION_NONE);
   gtk_list_box_set_header_func (GTK_LIST_BOX (box), update_header_func, NULL, NULL);
   gtk_list_box_set_sort_func (GTK_LIST_BOX (box), ap_sort, NULL, NULL);
+  gtk_list_box_set_placeholder (GTK_LIST_BOX (box), WID ("no-network-label"));
 
   g_signal_connect (box, "row-activated",
                     G_CALLBACK (row_activated), page);

--- a/gnome-initial-setup/pages/network/gis-network-page.ui
+++ b/gnome-initial-setup/pages/network/gis-network-page.ui
@@ -6,6 +6,7 @@
     <property name="visible">True</property>
     <property name="margin-left">80</property>
     <property name="margin-right">80</property>
+    <property name="row-spacing">6</property>
     <property name="halign">fill</property>
     <property name="valign">fill</property>
     <child>

--- a/gnome-initial-setup/pages/network/gis-network-page.ui
+++ b/gnome-initial-setup/pages/network/gis-network-page.ui
@@ -99,7 +99,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">3</property>
+        <property name="top_attach">4</property>
         <property name="width">1</property>
         <property name="height">1</property>
       </packing>
@@ -126,7 +126,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">4</property>
+        <property name="top_attach">5</property>
         <property name="width">1</property>
         <property name="height">1</property>
       </packing>
@@ -141,7 +141,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">5</property>
+        <property name="top_attach">3</property>
         <property name="width">1</property>
         <property name="height">1</property>
       </packing>

--- a/gnome-initial-setup/pages/network/gis-network-page.ui
+++ b/gnome-initial-setup/pages/network/gis-network-page.ui
@@ -106,33 +106,6 @@
       </packing>
     </child>
     <child>
-      <object class="GtkGrid" id="no-network-grid">
-        <property name="visible">True</property>
-        <property name="halign">start</property>
-        <property name="valign">start</property>
-        <child>
-          <object class="GtkLabel" id="no-network-label">
-            <property name="visible">True</property>
-            <property name="label" translatable="yes">No wireless available</property>
-            <property name="halign">center</property>
-            <property name="valign">center</property>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
-            <property name="width">1</property>
-            <property name="height">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="left_attach">0</property>
-        <property name="top_attach">5</property>
-        <property name="width">1</property>
-        <property name="height">1</property>
-      </packing>
-    </child>
-    <child>
       <object class="GtkCheckButton" id="skip-network-button">
         <property name="visible">True</property>
         <property name="label" translatable="yes">_Skip WiFi setup</property>
@@ -147,5 +120,12 @@
         <property name="height">1</property>
       </packing>
     </child>
+  </object>
+  <object class="GtkLabel" id="no-network-label">
+    <property name="visible">True</property>
+    <property name="label" translatable="yes">No wireless available</property>
+    <style>
+      <class name="dim-label" />
+    </style>
   </object>
 </interface>


### PR DESCRIPTION
This PR introduces the following changes:

 * The "Skip WiFi Setup" checkbox was moved above the list of networks, so it's always visible regardless of the number of hotspots
 * The vertical spacing between elements was improved
 * Instead of a plain black label, it now uses a placeholder in the listbox.

https://phabricator.endlessm.com/T11112