### PR TITLE
language-chooser: compare rows correctly

### DIFF
--- a/gnome-initial-setup/pages/language/cc-language-chooser.c
+++ b/gnome-initial-setup/pages/language/cc-language-chooser.c
@@ -315,7 +315,7 @@ sort_languages (GtkListBoxRow *a,
         LanguageWidget *la, *lb;
 
         la = get_language_widget (gtk_bin_get_child (GTK_BIN (a)));
-        lb = get_language_widget (gtk_bin_get_child (GTK_BIN (a)));
+        lb = get_language_widget (gtk_bin_get_child (GTK_BIN (b)));
 
         if (la == NULL)
                 return 1;


### PR DESCRIPTION
The current sorting function mistakenly tries to
compare row a with itself, instead of row a and b.

Fix that by properly gathering data from row a and b.

https://phabricator.endlessm.com/T11756