### PR TITLE
endless-eula: put the metrics label inside the checkbutton

### DIFF
--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
@@ -98,43 +98,28 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox" id="box1">
+      <object class="GtkCheckButton" id="metrics-checkbutton">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <child>
-          <object class="GtkCheckButton" id="metrics-checkbutton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="valign">start</property>
-            <property name="use_stock">True</property>
-            <property name="xalign">0</property>
-            <property name="yalign">0</property>
-            <property name="active">True</property>
-            <property name="draw_indicator">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="valign">start</property>
+        <property name="use_stock">True</property>
+        <property name="xalign">0</property>
+        <property name="yalign">0</property>
+        <property name="active">True</property>
+        <property name="draw_indicator">True</property>
         <child>
           <object class="GtkLabel" id="metrics-privacy-label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="valign">start</property>
             <property name="yalign">0</property>
+            <property name="margin_start">6</property>
             <property name="label" translatable="yes">Automatically save and send usage statistics and problem reports to Endless. All data is anonymous.</property>
             <property name="use_markup">True</property>
             <property name="wrap">True</property>
             <property name="max_width_chars">70</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
       <packing>


### PR DESCRIPTION
The metrics label is being treated separatedly of the check button,
which makes it not change the checkbutton state when the label is
clicked.

This behavior breaks the standard, expected behavior and can be very
frustrating, specially when the user doesn't have professional skills
with the mouse.

Fix that by putting the label inside the checkbutton.

https://phabricator.endlessm.com/T13578