### PR TITLE
eula: disable metrics on live systems

### DIFF
--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
@@ -329,6 +329,17 @@ gis_endless_eula_page_constructed (GObject *object)
   gtk_widget_show (GTK_WIDGET (page));
 
   widget = WID ("metrics-checkbutton");
+
+  /* Disable metrics on live sessions, and hide the option. */
+  if (gis_driver_is_live_session (GIS_PAGE (object)->driver))
+    {
+      gtk_widget_hide (WID ("metrics-separator"));
+      gtk_widget_hide (WID ("metrics-label"));
+      gtk_widget_hide (WID ("metrics-checkbutton-box"));
+
+      gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (widget), FALSE);
+    }
+
   g_signal_connect_swapped (widget, "toggled",
                             G_CALLBACK (sync_metrics_active_state), page);
 

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
@@ -68,7 +68,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSeparator" id="separator1">
+      <object class="GtkSeparator" id="metrics-separator">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
       </object>
@@ -98,7 +98,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkBox" id="box1">
+      <object class="GtkBox" id="metrics-checkbutton-box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>


### PR DESCRIPTION
Unfortunately, there are changes on master which prevent the same patch applying cleanly to both, so here is a eos3.0-specific patch.

https://phabricator.endlessm.com/T13890