### PR TITLE
network: populate wifi list even when already connected

### DIFF
--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -677,11 +677,13 @@ gis_network_page_constructed (GObject *object)
                                                G_CALLBACK (network_connectivity_changed_cb),
                                                page);
 
+  /*
+   * When there already is a working connection available, we hide the page from the
+   * setup but still populate it with the networks. If the user happens to disconnect
+   * after this page is created, we can still be able to connect to something afterwards.
+   */
   if (skip_page_for_ethernet_connection (page, monitor))
-    {
-      visible = FALSE;
-      goto out;
-    }
+    visible = FALSE;
 
   /* Check for available Wi-Fi devices */
   if (priv->nm_device == NULL) {


### PR DESCRIPTION
When the Initial Setup starts up and we detect a working connection,
the WiFi list isn't populated. If it happens that the computer is
disconnected before reaching the network page, we show the page again,
but nothing is set so the user effectively gets stuck in that page
forever.

Fix that by setting up the wifi device even if there's a connection
available.

https://phabricator.endlessm.com/T13749