### PR TITLE
T15370: disable chrome download when entering live mode

### DIFF
--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
@@ -73,7 +73,7 @@ create_live_user (GisLiveChooserPage *self)
                                        &error);
   if (error)
     {
-      g_warning ("Failed to created shared user: %s", error->message);
+      g_warning ("Failed to create live user: %s", error->message);
       g_clear_error (&error);
       return;
     }
@@ -89,7 +89,7 @@ create_live_user (GisLiveChooserPage *self)
   if (!gis_pkexec (LIBEXECDIR "/eos-setup-live-user", LIVE_ACCOUNT_USERNAME,
                    &error))
     {
-      g_warning ("%s\n", error->message);
+      g_warning ("Failed to setup live user: %s\n", error->message);
       g_clear_error (&error);
     }
 

--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
@@ -47,6 +47,19 @@ G_DEFINE_TYPE (GisLiveChooserPage, gis_live_chooser_page, GIS_TYPE_PAGE)
 #define WID(name) OBJ(GtkWidget*,name)
 
 static void
+disable_chrome_auto_download (GisLiveChooserPage *self)
+{
+  GError *error = NULL;
+
+  if (!gis_pkexec (DATADIR "eos-google-chrome-helper/eos-google-chrome-system-helper.py",
+                   NULL, &error))
+    {
+      g_warning ("Failed to disable Chrome auto-download: %s\n", error->message);
+      g_clear_error (&error);
+    }
+}
+
+static void
 create_live_user (GisLiveChooserPage *self)
 {
   ActUser *user;
@@ -137,6 +150,7 @@ static void
 try_button_clicked (GisLiveChooserPage *self)
 {
   create_live_user (self);
+  disable_chrome_auto_download (self);
   update_assistant (self);
 }
 


### PR DESCRIPTION
Run the eos-google-chrome-system-helper.py helper via pkexec which
touches a stamp file, making the automatic download of Google Chrome in
the user's session a no-op. The download/install consumes 250MB of
RAM from the tmpfs!

https://phabricator.endlessm.com/T15370