### PR TITLE
account: implement the new password strength scheme

### DIFF
--- a/gnome-initial-setup/pages/account/account.css
+++ b/gnome-initial-setup/pages/account/account.css
@@ -1,0 +1,15 @@
+/* Colors from the Tango palette */
+levelbar trough block.filled.weak {
+    background-color: #ef2929;
+    border-color: #cc0000;
+}
+
+levelbar trough block.filled.regular {
+    background-color: #edd400;
+    border-color: #c4a000;
+}
+
+levelbar trough block.filled.good {
+    background-color: #73d216;
+    border-color: #4e9a06;
+}

--- a/gnome-initial-setup/pages/account/account.gresource.xml
+++ b/gnome-initial-setup/pages/account/account.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/org/gnome/initial-setup">
+    <file alias="account.css">account.css</file>
     <file preprocess="xml-stripblanks" alias="gis-account-page.ui">gis-account-page.ui</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
The old password strength validation only starts giving us any
value when the password already has a good strength. This behavior
led to confusion, as it only actually works when after typing a
few random characters, making us think it wasn't working at all.

The new password scheme is just a minor extension of the old one.
Basically, whenever a password is typed, we make sure the strength
to be at least one - instead of 0 like before.

Now, we use the following scheme:

Empty	  -> 0 bars
Weak	  -> 1 bar (red)
Regular	  -> 2 bars (yellow)
Strong	  -> 3 bars (green)
Excellent -> 4 bars (blue)

This makes the feedback much more immediate, and improves the overall
interaction with the initial setup page.

https://phabricator.endlessm.com/T15307