### PR TITLE
keyboard: add us/us+intl default layouts as fallback

### DIFF
--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -321,7 +321,7 @@ no_results_widget_new (void)
         return widget;
 }
 
-static void
+static int
 add_rows_to_list (CcInputChooser  *chooser,
 	          GList            *list,
 	          const gchar      *type,
@@ -332,6 +332,7 @@ add_rows_to_list (CcInputChooser  *chooser,
 	const gchar *id;
 	GtkWidget *widget;
 	gchar *key;
+	int rows_added = 0;
 
 	for (; list; list = list->next) {
 		id = (const gchar *) list->data;
@@ -345,15 +346,18 @@ add_rows_to_list (CcInputChooser  *chooser,
 			continue;
 		}
 		g_hash_table_add (priv->inputs, key);
+		rows_added++;
 
 		if (g_hash_table_size (priv->inputs) > MIN_ROWS)
 			is_extra = TRUE;
 		widget = input_widget_new (chooser, type, id, is_extra);
 		gtk_container_add (GTK_CONTAINER (priv->input_list), widget);
 	}
+
+	return rows_added;
 }
 
-static void
+static int
 add_row_to_list (CcInputChooser *chooser,
 		 const gchar     *type,
 		 const gchar     *id,
@@ -361,7 +365,7 @@ add_row_to_list (CcInputChooser *chooser,
 {
 	GList tmp = { 0 };
 	tmp.data = (gpointer)id;
-	add_rows_to_list (chooser, &tmp, type, NULL, is_extra);
+	return add_rows_to_list (chooser, &tmp, type, NULL, is_extra);
 }
 
 static void
@@ -371,9 +375,10 @@ get_locale_infos (CcInputChooser *chooser)
 	const gchar *type, *id;
 	gchar *lang, *country;
 	GList *list;
+	int non_extra_layouts = 0;
 
 	if (gnome_get_input_source_from_locale (priv->locale, &type, &id)) {
-	  add_row_to_list (chooser, type, id, FALSE);
+		non_extra_layouts += add_row_to_list (chooser, type, id, FALSE);
 		if (!priv->id) {
 			priv->id = g_strdup (id);
 			priv->type = g_strdup (type);
@@ -384,12 +389,20 @@ get_locale_infos (CcInputChooser *chooser)
 		goto out;
 
 	list = gnome_xkb_info_get_layouts_for_language (priv->xkb_info, lang);
-	add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
+	non_extra_layouts += add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
 	g_list_free (list);
 
 	list = gnome_xkb_info_get_layouts_for_country (priv->xkb_info, country);
-	add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
+	non_extra_layouts += add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
 	g_list_free (list);
+
+	/* Add default us and us+intl non-extra layouts in case we could not
+	 * find anything more specific.
+	 */
+	if (non_extra_layouts == 0) {
+		add_row_to_list (chooser, INPUT_SOURCE_TYPE_XKB, "us", FALSE);
+		add_row_to_list (chooser, INPUT_SOURCE_TYPE_XKB, "us+intl", FALSE);
+	}
 
 	list = gnome_xkb_info_get_all_layouts (priv->xkb_info);
 	add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, TRUE);


### PR DESCRIPTION
When no more specific keyboard layouts have been found, add us and
us+intl as fallback options, instead of an empty list.

https://phabricator.endlessm.com/T15660