### PR TITLE
eos-test-mode: Update eos-updater unit usage

### DIFF
--- a/gnome-initial-setup/pages/language/eos-test-mode
+++ b/gnome-initial-setup/pages/language/eos-test-mode
@@ -48,5 +48,4 @@ if $extra_active; then
 fi
 
 # Disable the updater for this boot
-systemctl stop eos-updater.timer
-systemctl mask --runtime eos-updater.timer
+systemctl mask --runtime --now eos-autoupdater.timer eos-autoupdater.service


### PR DESCRIPTION
The unit files in eos-updater were recently changed, so that
eos-updater.service is now a unit in its own right, not an alias for
eos-autoupdater.service. Change the unit file handling to reflect that.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15977