### PR TITLE
live-chooser: set keyring password to empty string

### DIFF
--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
@@ -105,6 +105,7 @@ create_live_user (GisLiveChooserPage *self)
     }
 
   gis_driver_set_user_permissions (GIS_PAGE (self)->driver, user, NULL);
+  gis_update_login_keyring_password ("gis", "");
 
   g_object_unref (user);
 }


### PR DESCRIPTION
The gnome-initial-setup user creates a keyring for itself with the
passphrase 'gis'; this function updates the passphrase. The keyring is
then moved into the newly-created user's homedir when they log in, by
gnome-initial-setup-copy-worker.

(In the normal, non-live FBE flow, the keyring password is updated to
match that of the newly-created account, and the password is written in
plaintext to /run/gnome-initial-setup/.config/password. After moving the
keyring into position, copy-worker attempts to read this file and unlock
the keyring. We bypass the whole 'account' page, so this logic is
skipped.)

https://phabricator.endlessm.com/T15938