### PR TITLE
Re-enable metrics on live systems

### DIFF
--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
@@ -330,16 +330,6 @@ gis_endless_eula_page_constructed (GObject *object)
 
   priv->metrics_checkbutton = GTK_TOGGLE_BUTTON (WID ("metrics-checkbutton"));
 
-  /* Disable metrics on live sessions, and hide the option. */
-  if (gis_driver_is_live_session (GIS_PAGE (object)->driver))
-    {
-      gtk_widget_hide (WID ("metrics-separator"));
-      gtk_widget_hide (WID ("metrics-label"));
-      gtk_widget_hide (WID ("metrics-checkbutton"));
-
-      gtk_toggle_button_set_active (priv->metrics_checkbutton, FALSE);
-    }
-
   load_terms_view (page);
 
   gis_page_set_forward_text (GIS_PAGE (page), _("_Accept and Continue"));


### PR DESCRIPTION
This is a partial revert of #141. I left out the hunk which assigned an ID to the separator in the .ui file -- nice to have that, even if it's currently unused.

We previously had to disabled metrics on live systems because boot-time events (such as the fact that the system is live!) were lost on the first boot (ie every boot of a live system). Since the usage pattern of a live system is expected to be very different to a persistant installation, we need to be able to distinguish the two. Now that T14065 is resolved, this event will not be lost, so distinguishing live systems is possible, so we can re-enable metrics (by default) on live systems.

https://phabricator.endlessm.com/T14217