### PR TITLE
manually set LC_MESSAGES

### DIFF
--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -47,6 +47,8 @@
 
 #define MIN_ROWS 5
 
+#define GKBD_KEYBOARD_DISPLAY_CMD "/usr/bin/gkbd-keyboard-display"
+
 struct _CcInputChooserPrivate
 {
         GtkWidget *filter_entry;
@@ -169,7 +171,16 @@ preview_cb (GtkLabel       *label,
 	InputWidget *widget;
 	const gchar *layout;
 	const gchar *variant;
+	gchar *lc_msg = setlocale (LC_MESSAGES, NULL);
 	gchar *commandline;
+	gint argc;
+	gchar **argv = NULL;
+	gchar **env;
+	GError *error = NULL;
+	GPid pid;
+
+	env = g_get_environ ();
+	env = g_environ_setenv (env, "LC_MESSAGES", lc_msg, TRUE);
 
 	row = gtk_widget_get_parent (GTK_WIDGET (label));
 	widget = get_input_widget (row);
@@ -178,12 +189,40 @@ preview_cb (GtkLabel       *label,
 		return TRUE;
 
 	if (variant[0])
-		commandline = g_strdup_printf ("gkbd-keyboard-display -l \"%s\t%s\"", layout, variant);
+		commandline = g_strdup_printf (GKBD_KEYBOARD_DISPLAY_CMD" -l \"%s\t%s\"", layout, variant);
 	else
-		commandline = g_strdup_printf ("gkbd-keyboard-display -l %s", layout);
-	g_spawn_command_line_async (commandline, NULL);
-	g_free (commandline);
+		commandline = g_strdup_printf (GKBD_KEYBOARD_DISPLAY_CMD" -l %s", layout);
 
+	g_shell_parse_argv (commandline,
+			    &argc,
+			    &argv,
+			    &error);
+
+	if (error) {
+		g_critical ("Error parsing gkbd-keyboard-display command: %s", error->message);
+		g_clear_error (&error);
+		goto out;
+	}
+
+	g_spawn_async (NULL,
+		       argv,
+		       env,
+		       G_SPAWN_DEFAULT,
+		       NULL,
+		       NULL,
+		       &pid,
+		       &error);
+
+	if (error) {
+		g_critical ("Error running gkbd-keyboard-display: %s", error->message);
+		g_clear_error (&error);
+		goto out;
+	}
+
+out:
+	g_strfreev (env);
+	g_strfreev (argv);
+	g_free (commandline);
 	return TRUE;
 }
 

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -127,12 +127,10 @@ language_changed (CcLanguageChooser  *chooser,
   driver = GIS_PAGE (page)->driver;
 
   setlocale (LC_MESSAGES, priv->new_locale_id);
-  setlocale (LC_TIME, priv->new_locale_id);
   gtk_widget_set_default_direction (gtk_get_locale_direction ());
 
   /* gis spawns processes that also need to be localised */
   g_setenv ("LC_MESSAGES", priv->new_locale_id, TRUE);
-  g_setenv ("LC_TIME", priv->new_locale_id, TRUE);
 
   if (gis_driver_get_mode (driver) == GIS_DRIVER_MODE_NEW_USER) {
       if (g_permission_get_allowed (priv->permission)) {

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -129,9 +129,6 @@ language_changed (CcLanguageChooser  *chooser,
   setlocale (LC_MESSAGES, priv->new_locale_id);
   gtk_widget_set_default_direction (gtk_get_locale_direction ());
 
-  /* gis spawns processes that also need to be localised */
-  g_setenv ("LC_MESSAGES", priv->new_locale_id, TRUE);
-
   if (gis_driver_get_mode (driver) == GIS_DRIVER_MODE_NEW_USER) {
       if (g_permission_get_allowed (priv->permission)) {
           set_localed_locale (page);


### PR DESCRIPTION
This PR address a possible race between `setenv` and `getnev` manually copy the environment and adding `LC_MESSAGE` environment variable instead of relying on environment inheritance.

Ticket https://phabricator.endlessm.com/T17304