### PR TITLE
summary: limit width of live mode warning

### DIFF
--- a/gnome-initial-setup/pages/summary/gis-summary-page.ui
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.ui
@@ -59,6 +59,7 @@
                 <property name="orientation">horizontal</property>
                 <property name="margin_start">24</property>
                 <property name="margin_end">24</property>
+                <property name="margin_bottom">6</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkImage" id="warning_icon">
@@ -75,6 +76,7 @@
                     <property name="visible">True</property>
                     <property name="justify">left</property>
                     <property name="wrap">True</property>
+                    <property name="max-width-chars">60</property>
                   </object>
                 </child>
               </object>


### PR DESCRIPTION
Unscientific straw polls of the London team concluded that this is about the right point to wrap the text, and that a little extra margin below makes the elements look more balanced.

https://phabricator.endlessm.com/T17622