### PR TITLE
input-chooser: allow CcInputChooser to expand

### DIFF
--- a/gnome-initial-setup/pages/keyboard/input-chooser.ui
+++ b/gnome-initial-setup/pages/keyboard/input-chooser.ui
@@ -5,6 +5,7 @@
     <property name="visible">True</property>
     <property name="orientation">vertical</property>
     <property name="spacing">10</property>
+    <property name="expand">True</property>
     <child>
       <object class="GtkScrolledWindow" id="scrolled_window">
         <property name="visible">True</property>


### PR DESCRIPTION
CCInputCooser widget needs to expand when the user wants to see
more keyboard layouts.

https://phabricator.endlessm.com/T17605