### PR TITLE
Fix adding the reformatter to the taskbar

### DIFF
--- a/gnome-initial-setup/pages/live-chooser/eos-setup-live-user
+++ b/gnome-initial-setup/pages/live-chooser/eos-setup-live-user
@@ -41,7 +41,7 @@ GOOGLE_CHROME = 'google-chrome.desktop'
 CHROMIUM_BROWSER = 'chromium-browser.desktop'
 
 SHELL_SCHEMA = 'org.gnome.shell'
-TASKBAR_PINS = 'taskbar-pins'
+FAVORITE_APPS_KEY = 'favorite-apps'
 
 GS_SCHEMA = 'org.gnome.software'
 ALLOW_UPDATES = 'allow-updates'
@@ -89,7 +89,7 @@ class SetupLiveUser(object):
 
     def prepare(self):
         self.add_symlink()
-        self.update_taskbar_pins()
+        self.update_favorite_apps()
         self.disallow_app_center_updates()
 
     def write_gsettings(self):
@@ -148,28 +148,28 @@ class SetupLiveUser(object):
             log.info('symlinking %s to %s', EOS_INSTALLER, user_desktop_path)
             os.symlink(EOS_INSTALLER_PATH, user_desktop_path)
 
-    def update_taskbar_pins(self):
+    def update_favorite_apps(self):
         updates = self.updates[SHELL_SCHEMA]
-        taskbar_pins = updates.get_settings().get_strv(TASKBAR_PINS)
+        favorite_apps = updates.get_settings().get_strv(FAVORITE_APPS_KEY)
         changed = False
 
         # Prepend installer icon
-        if EOS_INSTALLER not in taskbar_pins:
-            taskbar_pins.insert(0, EOS_INSTALLER)
+        if EOS_INSTALLER not in favorite_apps:
+            favorite_apps.insert(0, EOS_INSTALLER)
             changed = True
 
         # Replace Chrome (downloaded on demand) with Chromium (pre-installed).
         # This effectively undoes a step taken in the image builder,
         # pre-seeding /var/eos-image-defaults/settings with the opposite
         # change.
-        if GOOGLE_CHROME in taskbar_pins:
-            i = taskbar_pins.index(GOOGLE_CHROME)
-            taskbar_pins[i] = CHROMIUM_BROWSER
+        if GOOGLE_CHROME in favorite_apps:
+            i = favorite_apps.index(GOOGLE_CHROME)
+            favorite_apps[i] = CHROMIUM_BROWSER
             changed = True
 
         if changed:
-            self.update(SHELL_SCHEMA, TASKBAR_PINS,
-                        GLib.Variant('as', taskbar_pins))
+            self.update(SHELL_SCHEMA, FAVORITE_APPS_KEY,
+                        GLib.Variant('as', favorite_apps))
 
     def disallow_app_center_updates (self):
         self.update(GS_SCHEMA, ALLOW_UPDATES, GLib.Variant('b', False))

--- a/gnome-initial-setup/pages/live-chooser/eos-setup-live-user
+++ b/gnome-initial-setup/pages/live-chooser/eos-setup-live-user
@@ -46,6 +46,7 @@ FAVORITE_APPS_KEY = 'favorite-apps'
 GS_SCHEMA = 'org.gnome.software'
 ALLOW_UPDATES = 'allow-updates'
 
+
 class SettingsUpdates(object):
     def __init__(self, schema):
         self._settings = Gio.Settings(schema=schema)
@@ -71,13 +72,15 @@ class SettingsUpdates(object):
         for key, value in self._updates.items():
             self._settings.set_value(key, value)
 
+
 class SetupLiveUser(object):
     def __init__(self):
         self.updates = {SHELL_SCHEMA: SettingsUpdates(SHELL_SCHEMA),
                         GS_SCHEMA: SettingsUpdates(GS_SCHEMA)}
 
     def update(self, schema, key, variant):
-        log.info('Updating {}: {} to {}'.format(schema, key, variant.print_(False)))
+        log.info('Updating %s: %s to %s',
+                 schema, key, variant.print_(False))
         self.updates[schema].set(key, variant)
 
     def format_keyfile(self):
@@ -171,7 +174,7 @@ class SetupLiveUser(object):
             self.update(SHELL_SCHEMA, FAVORITE_APPS_KEY,
                         GLib.Variant('as', favorite_apps))
 
-    def disallow_app_center_updates (self):
+    def disallow_app_center_updates(self):
         self.update(GS_SCHEMA, ALLOW_UPDATES, GLib.Variant('b', False))
 
 


### PR DESCRIPTION
In the Great GNOME Shell Rebase of Spring 2017, our downstream taskbar-pins GSetting was abandoned in favour of re-using upstream's favorite-apps GSetting.

Interestingly, without this change, the result is that only the reformatter appears on the taskbar! This is because the Shell imports the taskbar-pins key to favorite-apps, if it is not empty. The default is now empty; this script adds a single icon to it. :)

I also took this opportunity to fix some Python style problems.

https://phabricator.endlessm.com/T17622