### PR TITLE
set the envvar LC_MESSAGES

### DIFF
--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -129,6 +129,9 @@ language_changed (CcLanguageChooser  *chooser,
   setlocale (LC_MESSAGES, priv->new_locale_id);
   gtk_widget_set_default_direction (gtk_get_locale_direction ());
 
+  /* gis spawns processes that also need to be localised */
+  g_setenv ("LC_MESSAGES", priv->new_locale_id, TRUE);
+
   if (gis_driver_get_mode (driver) == GIS_DRIVER_MODE_NEW_USER) {
       if (g_permission_get_allowed (priv->permission)) {
           set_localed_locale (page);


### PR DESCRIPTION
When the user sets their preferred language, the environment variable
LC_MESSAGES shall be set too, because gis might spawns processes (e.g.
gkbd-keyboard-display) and they should be localised accordingly.

https://phabricator.endlessm.com/T3172
https://phabricator.endlessm.com/T17967