### PR TITLE
Ensure GOA displays the web view in the selected language

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,8 @@ PKG_CHECK_MODULES(ISOCODES, iso-codes)
 AC_DEFINE_UNQUOTED([ISO_CODES_PREFIX],["`$PKG_CONFIG --variable=prefix iso-codes`"],[ISO codes prefix])
 ISO_CODES=iso-codes
 
+AC_SUBST(SETLOCALE_WRAPPER_DIR, "\$(libdir)/gnome-initial-setup")
+
 AC_SUBST(INITIAL_SETUP_CFLAGS)
 AC_SUBST(INITIAL_SETUP_LIBS)
 

--- a/gnome-initial-setup/Makefile.am
+++ b/gnome-initial-setup/Makefile.am
@@ -17,7 +17,7 @@ AM_CPPFLAGS = \
 	-DLOCALSTATEDIR=\""$(localstatedir)"\" \
 	-DLIBEXECDIR=\""$(libexecdir)"\"
 
-libexec_PROGRAMS = gnome-initial-setup gnome-initial-setup-copy-worker
+libexec_PROGRAMS = gnome-initial-setup-exec gnome-initial-setup-copy-worker
 
 assistant_resource_files = $(shell glib-compile-resources --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/gis-assistant.gresource.xml)
 gis-assistant-resources.c: gis-assistant.gresource.xml $(assistant_resource_files)
@@ -33,7 +33,7 @@ gis-page-util-resources.h: gis-page-util.gresource.xml $(page_util_resource_file
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate-header $<
 BUILT_SOURCES += gis-page-util-resources.c gis-page-util-resources.h
 
-gnome_initial_setup_SOURCES = \
+gnome_initial_setup_exec_SOURCES = \
 	$(BUILT_SOURCES) \
 	gnome-initial-setup.c gnome-initial-setup.h \
 	gis-assistant.c gis-assistant.h \
@@ -43,7 +43,7 @@ gnome_initial_setup_SOURCES = \
 	gis-driver.c gis-driver.h \
 	gis-keyring.c gis-keyring.h
 
-gnome_initial_setup_LDADD =	\
+gnome_initial_setup_exec_LDADD =	\
 	pages/branding-welcome/libgisbrandingwelcome.la \
 	pages/language/libgislanguage.la \
 	pages/region/libgisregion.la \
@@ -72,8 +72,18 @@ gnome_initial_setup_copy_worker_CFLAGS = \
 gnome_initial_setup_copy_worker_LDADD = \
 	$(COPY_WORKER_LIBS)
 
+setlocalewrapperdir = $(SETLOCALE_WRAPPER_DIR)
+setlocalewrapper_LTLIBRARIES = libsetlocale-wrapper.la
+libsetlocale_wrapper_la_SOURCES = setlocale-wrapper.c
+
+gnome-initial-setup: gnome-initial-setup.in Makefile
+	$(AM_V_GEN) sed -e "s|@setlocale_wrapper_dir[@]|$(SETLOCALE_WRAPPER_DIR)|g;" -e "s|@libexecdir[@]|$(libexecdir)|g" $< > $@
+
+libexec_SCRIPTS = gnome-initial-setup
+
 EXTRA_DIST = \
 	gis-assistant.gresource.xml \
 	gis-page-util.gresource.xml \
 	$(assistant_resource_files) \
+	$(libexec_SCRIPTS)		\
 	$(page_util_resource_files)

--- a/gnome-initial-setup/gnome-initial-setup.in
+++ b/gnome-initial-setup/gnome-initial-setup.in
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+export LD_PRELOAD=@setlocale_wrapper_dir@/libsetlocale-wrapper.so
+exec @libexecdir@/gnome-initial-setup-exec $@

--- a/gnome-initial-setup/setlocale-wrapper.c
+++ b/gnome-initial-setup/setlocale-wrapper.c
@@ -1,0 +1,52 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * Copyright (C) 2017 Endless Mobile, Inc.
+ *
+ * Authors:
+ *   Joaquim Rocha <jrocha@endlessm.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define _GNU_SOURCE
+
+#include <string.h>
+#include <dlfcn.h>
+
+#define WRAPPER_LOCALE_BUF_LEN 32
+
+typedef char *(*setlocale_fn)(int category, const char *locale);
+static setlocale_fn setlocale_orig_func = NULL;
+
+static char wrapper_locale_current[WRAPPER_LOCALE_BUF_LEN] = "\0";
+
+char *
+setlocale (int category, const char *locale)
+{
+  setlocale_orig_func = (setlocale_fn) dlsym (RTLD_NEXT, "setlocale");
+
+  if (locale != NULL) {
+    char *setup_locale = setlocale_orig_func (category, locale);
+
+    /* if the original setlocale function failed to set up the new locale, then
+     * we also fail */
+    if (setup_locale == NULL)
+      return NULL;
+
+    strncpy (wrapper_locale_current, setup_locale, WRAPPER_LOCALE_BUF_LEN);
+  } else if (strlen (wrapper_locale_current) == 0) {
+    return setlocale_orig_func (category, NULL);
+  }
+  return wrapper_locale_current;
+}


### PR DESCRIPTION
When a user chooses a different language in the first screen of
gnome-initial-setup, the web view provided by GNOME Online Accounts
will still display the original language in which the app has been
launched. This is obviously an issue for users who may find it hard
to connect to their online accounts because of not using their
language.

Since the web view is controled by a different library, the cleanest
way to make it obey the language change is to override the set_locale
function (using LD_PRELOAD) and make it return the language that the
user has set.
Because of this I have had to wrap the gnome-initial-setup binary in
a script that sets up the environment variable before calling the real
executable.

https://phabricator.endlessm.com/T18041