### PR TITLE
live-chooser: ensure both columns have the same width

### DIFF
--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.ui
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.ui
@@ -3,15 +3,6 @@
   <!-- interface-requires gtk+ 3.0 -->
   <template class="GisLiveChooserPage" parent="GisPage">
     <child>
-      <object class="GtkPopover" id="language_popover">
-        <property name="can_focus">False</property>
-        <child>
-          <object class="CcLanguageChooser" id="language_chooser">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-        </child>
-      </object>
       <object class="GtkBox" id="main_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>

--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.ui
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.ui
@@ -19,6 +19,7 @@
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <property name="spacing">24</property>
+            <property name="homogeneous">True</property>
             <child>
               <object class="GtkFrame">
                 <property name="visible">True</property>


### PR DESCRIPTION
Previously, in English (and possibly other languages), the two columns are
allocated different widths (310 vs 289 px). This in turn leads to the two
labels ("Try Endless OS by running it from the USB stick" and
"Reformat this computer with Endless OS") to be allocated different
heights, even though they are in the same vertical size group, and even
though both strings only actually occupy two lines. The narrower label was
allocated extra height for a third line of text.  This has the knock-on
effect of the icon and the buttons not being vertically aligned.

I think this might be an interaction with height-for-width? Quoth the
GtkSizeGroup documentation:

> Note that size groups only affect the amount of space requested, not
> the size that the widgets finally receive. If you want the widgets in
> a GtkSizeGroup to actually be the same size, you need to pack them in
> such a way that they get the size they request and not more.

I confess that I don't really understand exactly what's going on here, but
regardless of the misalignment we want the two columns to be the same
width; and fixing this also resolves the size allocation.

Bisecting shows that this issue was introduced by d276a0a; which is strange
because this is a simple forward-port of a patch from eos3.1 which didn't
have this problem.

https://phabricator.endlessm.com/T18063