### PR TITLE
Inhibit the idle state when running g-i-s

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -488,6 +488,10 @@ gis_driver_startup (GApplication *app)
                                     "deletable", FALSE,
                                     NULL);
 
+  gtk_application_inhibit (GTK_APPLICATION (app), priv->main_window,
+                           GTK_APPLICATION_INHIBIT_IDLE,
+                           "Should not be idle on first boot.");
+
   g_signal_connect (priv->main_window,
                     "realize",
                     G_CALLBACK (window_realize_cb),


### PR DESCRIPTION
The g-i-s is a top priority application and one that should be
left idle, so it makes sense to keep the user focused on it and not
let the system be idle either (it's not a great UX if the user sees the
lock screen's shield on first boot).

https://phabricator.endlessm.com/T18045