### PR TITLE
Distribute g-i-s.in, clean generated wrapper

### DIFF
--- a/gnome-initial-setup/Makefile.am
+++ b/gnome-initial-setup/Makefile.am
@@ -84,6 +84,11 @@ libexec_SCRIPTS = gnome-initial-setup
 EXTRA_DIST = \
 	gis-assistant.gresource.xml \
 	gis-page-util.gresource.xml \
+	gnome-initial-setup.in \
 	$(assistant_resource_files) \
 	$(libexec_SCRIPTS)		\
 	$(page_util_resource_files)
+
+CLEANFILES = \
+	gnome-initial-setup \
+	$(NULL)


### PR DESCRIPTION
Without these, building from a tarball fails because
gnome-initial-setup.in does not exist, and make distcheck additionally
fails because gnome-initial-setup/gnome-initial-setup is left over after
`make clean`.

https://phabricator.endlessm.com/T18041