### PR TITLE
setlocale-wrapper: pass -ldl to linker

### DIFF
--- a/gnome-initial-setup/Makefile.am
+++ b/gnome-initial-setup/Makefile.am
@@ -75,6 +75,7 @@ gnome_initial_setup_copy_worker_LDADD = \
 setlocalewrapperdir = $(SETLOCALE_WRAPPER_DIR)
 setlocalewrapper_LTLIBRARIES = libsetlocale-wrapper.la
 libsetlocale_wrapper_la_SOURCES = setlocale-wrapper.c
+libsetlocale_wrapper_la_LIBADD = -ldl
 
 gnome-initial-setup: gnome-initial-setup.in Makefile
 	$(AM_V_GEN) sed -e "s|@setlocale_wrapper_dir[@]|$(SETLOCALE_WRAPPER_DIR)|g;" -e "s|@libexecdir[@]|$(libexecdir)|g" $< > $@


### PR DESCRIPTION
From OBS:

    libtool: link: gcc -shared  -fPIC -DPIC  .libs/setlocale-wrapper.o    -O2 -Wl,-Bsymbolic-functions -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,-z -Wl,defs -Wl,-O1 -Wl,--as-needed   -Wl,-soname -Wl,libsetlocale-wrapper.so.0 -o .libs/libsetlocale-wrapper.so.0.0.0
    .libs/setlocale-wrapper.o: In function `setlocale':
    /usr/src/packages/BUILD/gnome-initial-setup-3.22.1+dev177.e4922f5/gnome-initial-setup/setlocale-wrapper.c:37: undefined reference to `dlsym'
    collect2: error: ld returned 1 exit status
    Makefile:593: recipe for target 'libsetlocale-wrapper.la' failed

I cannot reproduce this by building the debian package locally but there we are.

https://phabricator.endlessm.com/T18041