### PR TITLE
language: allow to specify initial languages from vendor.conf

### DIFF
--- a/gnome-initial-setup/pages/language/Makefile.am
+++ b/gnome-initial-setup/pages/language/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = \
 	-I"$(top_srcdir)" \
 	-I"$(top_srcdir)/gnome-initial-setup" \
 	-I"$(top_builddir)" \
+	-DVENDOR_CONF_FILE="\"$(VENDOR_CONF_FILE)\"" \
 	-DDATADIR=\""$(datadir)"\" \
 	-DGNOMELOCALEDIR=\""$(datadir)/locale"\"
 


### PR DESCRIPTION
Instead of hardcoding the initial list, we can use vendor.conf to seed
it; we still use the hardcoded defaults when that's not the case.

https://phabricator.endlessm.com/T17467