### PR TITLE
endless-eula: fix regression when setting metrics state

### DIFF
--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
@@ -401,13 +401,6 @@ gis_endless_eula_page_constructed (GObject *object)
   load_css_overrides (page);
 
   gtk_widget_show (GTK_WIDGET (page));
-
-  widget = priv->metrics_checkbutton;
-
-  g_signal_connect_swapped (widget, "toggled",
-                            G_CALLBACK (sync_metrics_active_state), page);
-
-  sync_metrics_active_state (page);
   load_terms_view (page);
 
   gis_page_set_forward_text (GIS_PAGE (page), _("_Accept and Continue"));


### PR DESCRIPTION
https://github.com/endlessm/gnome-initial-setup/pull/161 changed g-i-s
to only set the metrics enabled state at the end of the FBE; the change
from commit 21076e25ea62b4177c6c67c518254d7c4cbf5425 was lost during
our rebase for eos3.2. Make sure to apply that code again.

https://phabricator.endlessm.com/T18943