### PR TITLE
driver: determine DVD-ness from image version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,6 @@ PKG_CHECK_MODULES(INITIAL_SETUP,
                   pwquality
                   evince-view-3.0
                   evince-document-3.0
-                  udisks2
                   webkit2gtk-4.0)
 
 INITIAL_SETUP_CFLAGS="$INITIAL_SETUP_CFLAGS -DNM_VERSION_MIN_REQUIRED=NM_VERSION_1_2"

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -26,8 +26,6 @@
 #include <stdlib.h>
 #include <locale.h>
 
-#include <udisks/udisks.h>
-
 #include "gis-assistant.h"
 
 #define GIS_TYPE_DRIVER_MODE (gis_driver_mode_get_type ())
@@ -81,7 +79,6 @@ struct _GisDriverPrivate {
   gchar *username;
 
   gboolean is_live_session;
-  gchar *live_mode_uuid;
   gboolean is_live_dvd;
   gboolean is_in_demo_mode;
   gboolean show_demo_mode;
@@ -108,13 +105,12 @@ check_for_live_boot (gchar **uuid)
   g_autoptr(GRegex) reg = NULL;
   g_autoptr(GMatchInfo) info = NULL;
 
-  g_return_val_if_fail (uuid != NULL, FALSE);
-
   force = g_getenv ("EI_FORCE_LIVE_BOOT_UUID");
   if (force != NULL && *force != '\0')
     {
       g_print ("EI_FORCE_LIVE_BOOT_UUID set to %s\n", force);
-      *uuid = g_strdup (force);
+      if (uuid != NULL)
+        *uuid = g_strdup (force);
       return TRUE;
     }
 
@@ -129,78 +125,37 @@ check_for_live_boot (gchar **uuid)
 
   g_print ("set live_boot to %u from /proc/cmdline: %s\n", live_boot, cmdline);
 
-  reg = g_regex_new ("\\bendless\\.image\\.device=UUID=([^\\s]*)", 0, 0, NULL);
-  g_regex_match (reg, cmdline, 0, &info);
-  if (g_match_info_matches (info))
+  if (uuid != NULL)
     {
-      *uuid = g_match_info_fetch (info, 1);
-      g_print ("set UUID to %s\n", *uuid);
+      reg = g_regex_new ("\\bendless\\.image\\.device=UUID=([^\\s]*)", 0, 0, NULL);
+      g_regex_match (reg, cmdline, 0, &info);
+      if (g_match_info_matches (info))
+        {
+          *uuid = g_match_info_fetch (info, 1);
+          g_print ("set UUID to %s\n", *uuid);
+        }
     }
 
   return live_boot;
 }
 
 static void
-udisks_client_new_cb (GObject      *source,
-                      GAsyncResult *result,
-                      gpointer      user_data)
-{
-  GisDriver *driver = GIS_DRIVER (user_data);
-  GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
-  UDisksClient *udisks = NULL;
-  GError *error = NULL;
-
-  udisks = udisks_client_new_finish (result, &error);
-  if (udisks != NULL)
-    {
-      GList *blocks = udisks_client_get_block_for_uuid (udisks, priv->live_mode_uuid);
-      GList *l;
-
-      /* If you have the same ISO on a USB and a DVD and you insert both, it is
-       * hard to determine which is booted using UDisks, so assume it's the DVD.
-       */
-      for (l = blocks; l != NULL && !priv->is_live_dvd; l = l->next)
-        {
-          UDisksBlock *block = UDISKS_BLOCK (l->data);
-          UDisksDrive *drive = udisks_client_get_drive_for_block (udisks, block);
-
-          if (drive != NULL && udisks_drive_get_optical (drive))
-            {
-              priv->is_live_dvd = TRUE;
-              g_object_notify_by_pspec (G_OBJECT (driver), obj_props[PROP_LIVE_DVD]);
-            }
-
-          g_clear_object (&drive);
-        }
-
-      g_list_free_full (blocks, g_object_unref);
-    }
-  else if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-    {
-      g_warning ("Couldn't connect to UDisks: %s %d %s",
-          g_quark_to_string (error->domain), error->code, error->message);
-      g_message ("Assuming live disk is not optical");
-    }
-
-  g_clear_error (&error);
-  g_clear_object (&udisks);
-  g_clear_object (&driver);
-}
-
-static gboolean
-running_live_session (GisDriver *driver)
+check_live_session (GisDriver   *driver,
+                    const gchar *image_version)
 {
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
 
-  if (!check_for_live_boot (&priv->live_mode_uuid))
-    return FALSE;
-
-  /* Check whether this is a DVD, without blocking FBE initialization. This is
-   * likely to return before the user completes the language page.
-   */
-  udisks_client_new (priv->cancellable, udisks_client_new_cb, g_object_ref (driver));
-
-  return TRUE;
+  if (check_for_live_boot (NULL))
+    {
+      priv->is_live_session = TRUE;
+      priv->is_live_dvd = image_version != NULL &&
+        g_str_has_prefix (image_version, "eosdvd-");
+    }
+  else
+    {
+      priv->is_live_session = FALSE;
+      priv->is_live_dvd = FALSE;
+    }
 }
 
 #define EOS_IMAGE_VERSION_PATH "/sysroot"
@@ -236,7 +191,6 @@ gis_driver_finalize (GObject *object)
   g_free (priv->lang_id);
   g_free (priv->username);
   g_free (priv->user_password);
-  g_free (priv->live_mode_uuid);
 
   g_clear_object (&priv->user_account);
   g_clear_object (&priv->cancellable);
@@ -837,8 +791,9 @@ gis_driver_startup (GApplication *app)
 
   image_version = get_image_version ();
 
-  priv->is_live_session = running_live_session (driver);
+  check_live_session (driver, image_version);
   g_object_notify_by_pspec (G_OBJECT (driver), obj_props[PROP_LIVE_SESSION]);
+  g_object_notify_by_pspec (G_OBJECT (driver), obj_props[PROP_LIVE_DVD]);
 
   priv->show_demo_mode = !priv->is_live_session && image_supports_demo_mode (image_version);
 

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -95,6 +95,8 @@ void gis_driver_enter_demo_mode (GisDriver *driver);
 
 gboolean gis_driver_get_supports_demo_mode (GisDriver *driver);
 
+gboolean gis_driver_get_show_demo_mode (GisDriver *driver);
+
 gboolean gis_driver_is_in_demo_mode (GisDriver *driver);
 
 gboolean gis_driver_is_live_session (GisDriver *driver);

--- a/gnome-initial-setup/gis-page-util.c
+++ b/gnome-initial-setup/gis-page-util.c
@@ -171,25 +171,29 @@ get_have_sdcard (void)
   return has_bundles;
 }
 
-static gchar *
-get_sdcard_version (void)
+gchar *
+gis_page_util_get_image_version (const gchar *path)
 {
   ssize_t attrsize;
   gchar *value;
 
-  attrsize = getxattr (SD_CARD_MOUNT, EOS_IMAGE_VERSION_XATTR, NULL, 0);
+  g_return_val_if_fail (path != NULL, NULL);
+
+  attrsize = getxattr (path, EOS_IMAGE_VERSION_XATTR, NULL, 0);
   if (attrsize < 0) {
-    g_warning ("Error examining SD card xattr: %s", g_strerror (errno));
+    g_message ("Error examining " EOS_IMAGE_VERSION_XATTR " on %s: %s",
+               path, g_strerror (errno));
     return NULL;
   }
 
   value = g_malloc (attrsize + 1);
   value[attrsize] = 0;
 
-  attrsize = getxattr (SD_CARD_MOUNT, EOS_IMAGE_VERSION_XATTR, value,
+  attrsize = getxattr (path, EOS_IMAGE_VERSION_XATTR, value,
                        attrsize);
   if (attrsize < 0) {
-    g_warning ("Error reading SD card xattr: %s", g_strerror (errno));
+    g_warning ("Error reading " EOS_IMAGE_VERSION_XATTR " on %s: %s",
+               path, g_strerror (errno));
     g_free (value);
     return NULL;
   }
@@ -412,7 +416,7 @@ gis_page_util_show_factory_dialog (GisPage *page)
   }
 
   if (get_have_sdcard ())
-    sd_version = get_sdcard_version ();
+    sd_version = gis_page_util_get_image_version (SD_CARD_MOUNT);
 
   if (!sd_version)
     sd_version = g_strdup (_("Disabled"));

--- a/gnome-initial-setup/gis-page-util.h
+++ b/gnome-initial-setup/gis-page-util.h
@@ -31,6 +31,8 @@ G_BEGIN_DECLS
 void gis_page_util_show_factory_dialog (GisPage *page);
 void gis_page_util_show_demo_dialog (GisPage *page);
 
+gchar *gis_page_util_get_image_version (const gchar *path);
+
 G_END_DECLS
 
 #endif

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -37,7 +37,6 @@
 #include "gis-language-page.h"
 
 #include <act/act-user-manager.h>
-#include <attr/xattr.h>
 #include <polkit/polkit.h>
 #include <locale.h>
 #include <gtk/gtk.h>
@@ -257,48 +256,18 @@ language_confirmed (CcLanguageChooser *chooser,
   gis_assistant_next_page (gis_driver_get_assistant (GIS_PAGE (page)->driver));
 }
 
-#define EOS_IMAGE_VERSION_XATTR "user.eos-image-version"
 #define EOS_IMAGE_VERSION_PATH "/sysroot"
 #define EOS_IMAGE_VERSION_ALT_PATH "/"
-
-static char *
-get_image_version_for_path (const char *path)
-{
-  ssize_t xattr_size = 0;
-  char *image_version = NULL;
-
-  xattr_size = getxattr (path, EOS_IMAGE_VERSION_XATTR, NULL, 0);
-
-  if (xattr_size == -1)
-    return NULL;
-
-  image_version = g_malloc0 (xattr_size + 1);
-
-  xattr_size = getxattr (path, EOS_IMAGE_VERSION_XATTR,
-                         image_version, xattr_size);
-
-  /* this check is just in case the xattr has changed in between the
-   * size checks */
-  if (xattr_size == -1)
-    {
-      g_warning ("Error when getting the 'eos-image-version' from %s",
-                 path);
-      g_free (image_version);
-      return NULL;
-    }
-
-  return image_version;
-}
 
 static char *
 get_image_version (void)
 {
   char *image_version =
-    get_image_version_for_path (EOS_IMAGE_VERSION_PATH);
+    gis_page_util_get_image_version (EOS_IMAGE_VERSION_PATH);
 
   if (!image_version)
     image_version =
-      get_image_version_for_path (EOS_IMAGE_VERSION_ALT_PATH);
+      gis_page_util_get_image_version (EOS_IMAGE_VERSION_ALT_PATH);
 
   return image_version;
 }

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -256,39 +256,6 @@ language_confirmed (CcLanguageChooser *chooser,
   gis_assistant_next_page (gis_driver_get_assistant (GIS_PAGE (page)->driver));
 }
 
-#define EOS_IMAGE_VERSION_PATH "/sysroot"
-#define EOS_IMAGE_VERSION_ALT_PATH "/"
-
-static char *
-get_image_version (void)
-{
-  char *image_version =
-    gis_page_util_get_image_version (EOS_IMAGE_VERSION_PATH);
-
-  if (!image_version)
-    image_version =
-      gis_page_util_get_image_version (EOS_IMAGE_VERSION_ALT_PATH);
-
-  return image_version;
-}
-
-static gboolean
-image_supports_demo_mode (void)
-{
-  char *image_version = NULL;
-  gboolean res;
-
-  image_version = get_image_version ();
-  if (!image_version)
-    return FALSE;
-
-  res = g_str_has_prefix (image_version, "eosnonfree-") ||
-    g_str_has_prefix (image_version, "eosoem-");
-  g_free (image_version);
-
-  return res;
-}
-
 static void
 update_demo_mode_label (GisLanguagePage *page)
 {
@@ -300,9 +267,7 @@ update_demo_mode_label (GisLanguagePage *page)
   g_free (text);
 
   gtk_widget_set_visible (priv->demo_mode_label,
-                          gis_driver_get_supports_demo_mode (GIS_PAGE (page)->driver) &&
-                          image_supports_demo_mode () &&
-                          !gis_driver_is_in_demo_mode (GIS_PAGE (page)->driver));
+                          gis_driver_get_show_demo_mode (GIS_PAGE (page)->driver));
 }
 
 static void


### PR DESCRIPTION
This is not as aesthetically pleasing as using UDisks and will produce incorrect results if a non-eosdvd ISO (ie base – no others fit) is written to DVD or an eosdvd ISO is written to USB.

But the UDisks approach does not actually work: when booted from a DVD, for annoying reasons the udev properties indicating the media in the drive are missing for the DVD device, so UDisks doesn't believe it to be an optical device.

This approach is simpler and easier to test.

I reused (and deduplicated) the logic used to trigger the demo mode label. I gave it a quick spin in all these conditions:

* `/sysroot` has `eos-image-version` `eosoem-foo`, not live mode => label
* `/sysroot` has `eos-image-version` `eosoem-foo`, live mode => no label, Ctrl-D does nothing
* `/sysroot` has no `eos-image-version`, `/` has `eos-image-version` `eos-...` => no label, Ctrl-D shows dialog

https://phabricator.endlessm.com/T18708