### PR TITLE
Revert "Add libudisks2 dependency"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,6 @@ Build-Depends: debhelper (>= 10),
                libattr1-dev,
                libevince-dev,
                libgnome-keyring-dev,
-               libudisks2-dev,
                zint-devel
 Standards-Version: 3.9.8
 Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/unstable/gnome-initial-setup

--- a/debian/control.in
+++ b/debian/control.in
@@ -35,7 +35,6 @@ Build-Depends: debhelper (>= 10),
                libattr1-dev,
                libevince-dev,
                libgnome-keyring-dev,
-               libudisks2-dev,
                zint-devel
 Standards-Version: 3.9.8
 Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/desktop/unstable/gnome-initial-setup


### PR DESCRIPTION
This reverts commit 4d0a66098fcff2d1a6be782374e3aa4eac7feecb.

Depends on https://github.com/endlessm/gnome-initial-setup/pull/212

https://phabricator.endlessm.com/T18708