### PR TITLE
Revert "demo-mode: check that /run/gnome-initial-setup/eos-demo-mode …

### DIFF
--- a/data/com.endlessm.DemoMode.rules
+++ b/data/com.endlessm.DemoMode.rules
@@ -5,11 +5,6 @@ polkit.addRule(function(action, subject) {
          action.id == "org.freedesktop.Flatpak.runtime-uninstall") &&
         subject.active == true && subject.local == true &&
         subject.user == "demo-guest") {
-            try {
-                    polkit.spawn(["/bin/test", "-e", "/run/gnome-initial-setup/eos-demo-mode"]);
-                    return polkit.Result.YES;
-            } catch (e) {
-                    // no-op
-            }
+            return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
…exists"

polkit.spawn() will spawn the process using the polkitd user, which
won't have access to that file.

This reverts commit d9dc63e31b22460e2b626cb13ea71483fd4291bd.

https://phabricator.endlessm.com/T18999