### PR TITLE
endless-eula: create page also in demo mode

### DIFF
--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
@@ -381,6 +381,7 @@ gis_endless_eula_page_constructed (GObject *object)
   GisEndlessEulaPagePrivate *priv = gis_endless_eula_page_get_instance_private (page);
   GError *error = NULL;
   GtkWidget *widget;
+  gboolean demo_mode;
 
   G_OBJECT_CLASS (gis_endless_eula_page_parent_class)->constructed (object);
 
@@ -405,6 +406,14 @@ gis_endless_eula_page_constructed (GObject *object)
 
   gis_page_set_forward_text (GIS_PAGE (page), _("_Accept and Continue"));
   gis_page_set_complete (GIS_PAGE (page), TRUE);
+
+  /* Hide the page in demo mode; we still want to create it, since we
+   * want the save_data implementation to run at the end of the FBE.
+   * Also, make sure metrics are off in that case.
+   */
+  demo_mode = gis_driver_is_in_demo_mode (GIS_PAGE (page)->driver);
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (priv->metrics_checkbutton), !demo_mode);
+  gtk_widget_set_visible (GTK_WIDGET (page), !demo_mode);
 }
 
 static void
@@ -452,9 +461,6 @@ gis_endless_eula_page_init (GisEndlessEulaPage *page)
 void
 gis_prepare_endless_eula_page (GisDriver *driver)
 {
-  if (gis_driver_is_in_demo_mode (driver))
-    return;
-
   gis_driver_add_page (driver,
                        g_object_new (GIS_TYPE_ENDLESS_EULA_PAGE,
                                      "driver", driver,


### PR DESCRIPTION
But make it invisible in that case; this ensures we still call
set_enabled() at the end of the FBE to definitively disable metrics.

https://phabricator.endlessm.com/T19227