### PR TITLE
Don't run gnome-initial-setup for existing users

### DIFF
--- a/gnome-initial-setup/gnome-initial-setup.c
+++ b/gnome-initial-setup/gnome-initial-setup.c
@@ -258,6 +258,14 @@ main (int argc, char *argv[])
     return EXIT_SUCCESS;
   }
 
+  /* Upstream has "existing user" mode for new user accounts, but we don't
+     want that in Endless, so skip it. In the future, we should be launching
+     the tutorial right from here, once it's again available. */
+  if (get_mode () == GIS_DRIVER_MODE_EXISTING_USER) {
+    gis_ensure_stamp_files ();
+    return EXIT_SUCCESS;
+  }
+
 #ifdef HAVE_CHEESE
   cheese_gtk_init (NULL, NULL);
 #endif


### PR DESCRIPTION
Upstream has "existing user" mode for new user accounts, but we don't
want that in Endless, so skip it. In the future, we should be launching
the tutorial right from here, once it's again available.

This change was introduced to fix T3727, but got lost during the rebase
to EOS 3.2. It's way simpler now because we don't have a tutorial now,
but in the near future should probably be reworked to launch the new
tutorial, once it's ready.

https://phabricator.endlessm.com/T19802