### PR TITLE
Add powerMenu to initial-setup shell mode

### DIFF
--- a/data/initial-setup.json
+++ b/data/initial-setup.json
@@ -3,6 +3,6 @@
     "components": ["networkAgent"],
     "panel": { "left": [],
                "center": [],
-               "right": ["a11yGreeter", "keyboard", "aggregateMenu"]
+               "right": ["a11yGreeter", "keyboard", "aggregateMenu", "powerMenu"]
     }
 }

--- a/gnome-initial-setup/pages/live-chooser/eos-setup-live-user
+++ b/gnome-initial-setup/pages/live-chooser/eos-setup-live-user
@@ -33,7 +33,7 @@ ICON_GRID_DIR = '/var/lib/eos-image-defaults/icon-grid'
 
 DESKTOP_GRID_ID = 'desktop'
 
-EOS_INSTALLER = 'eos-installer.desktop'
+EOS_INSTALLER = 'com.endlessm.Installer.desktop'
 GDM_APPS_DIR = '/usr/share/gdm/greeter/applications'
 EOS_INSTALLER_PATH = os.path.join(GDM_APPS_DIR, EOS_INSTALLER)
 

--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
@@ -45,8 +45,6 @@ struct _GisLiveChooserPagePrivate
   GtkWidget *try_button;
   GtkWidget *reformat_button;
 
-  GCancellable     *cancellable;
-
   ActUserManager   *act_client;
 };
 
@@ -231,9 +229,6 @@ gis_live_chooser_page_finalize (GObject *object)
 {
   GisLiveChooserPage *page = (GisLiveChooserPage *)object;
   GisLiveChooserPagePrivate *priv = gis_live_chooser_page_get_instance_private (page);
-
-  g_cancellable_cancel (priv->cancellable);
-  g_clear_object (&priv->cancellable);
 
   G_OBJECT_CLASS (gis_live_chooser_page_parent_class)->finalize (object);
 }


### PR DESCRIPTION
At present, there is no obvious way to shut down the system from the
FBE. (The factory test dialog, accessed with Ctrl+F on the first page,
does provide a Power Off button, but this is not user-visible.) This is
annoying if you've booted an Endless OS machine but want someone else to
complete the FBE. It's worse if you're on a live USB and are running the
reformatter, because it does not provide any way to cleanly shut down
the system short of reformatting your system!

Upstream, the power-off options are in the aggregateMenu, but in Endless
they've been moved to the Endless-specific userMenu component. We have
also introduced an Endless-specific powerMenu component for use at the
GDM login screen, so we can just add it to the initial-setup shell mode.
This adds a power-off button to the bottom-right corner of the shell,
allowing you to shut down, restart, or cancel.

https://phabricator.endlessm.com/T20103