### PR TITLE
Adjust for use on eosinstaller images

### DIFF
--- a/gnome-initial-setup/eos-transient-setup
+++ b/gnome-initial-setup/eos-transient-setup
@@ -35,8 +35,7 @@ ICON_GRID_DIR = '/var/lib/eos-image-defaults/icon-grid'
 DESKTOP_GRID_ID = 'desktop'
 
 EOS_INSTALLER = 'com.endlessm.Installer.desktop'
-GDM_APPS_DIR = '/usr/share/gdm/greeter/applications'
-EOS_INSTALLER_PATH = os.path.join(GDM_APPS_DIR, EOS_INSTALLER)
+EOS_INSTALLER_PATH = os.path.join('/usr/share/applications', EOS_INSTALLER)
 LOCAL_APPS_DIR = '/usr/local/share/applications'
 LOCAL_DESKTOP_PATH = os.path.join(LOCAL_APPS_DIR, EOS_INSTALLER)
 
@@ -155,19 +154,22 @@ class AdjustGSettings(object):
 
 
 def install_installer_desktop_file():
-    """Make eos-installer available to user sessions.
+    """Make eos-installer visible in user sessions.
 
-    eos-installer is shipped in all images, but its desktop file is
-    (deliberately) only present in the GDM greeter's environment. For live
-    boots, we symlink it into place so it can be added to the desktop and
-    taskbar and found via search.
+    eos-installer is shipped in all images, but its desktop file contains
+    NoDisplay=true. Make a copy with this setting removed so it can be added to
+    the desktop and taskbar and found via search.
     """
+    log.info('Copying %s to %s with NoDisplay removed',
+             EOS_INSTALLER_PATH, LOCAL_DESKTOP_PATH)
     os.makedirs(LOCAL_APPS_DIR, exist_ok=True)
-    try:
-        log.info('symlinking %s to %s', EOS_INSTALLER, LOCAL_DESKTOP_PATH)
-        os.symlink(EOS_INSTALLER_PATH, LOCAL_DESKTOP_PATH)
-    except FileExistsError:
-        pass
+
+    kf = GLib.KeyFile()
+    kf.load_from_file(EOS_INSTALLER_PATH,
+                      GLib.KeyFileFlags.KEEP_COMMENTS |
+                      GLib.KeyFileFlags.KEEP_TRANSLATIONS)
+    kf.remove_key('Desktop Entry', 'NoDisplay')
+    kf.save_to_file(LOCAL_DESKTOP_PATH)
 
 
 def disable_chrome_auto_download():

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -88,6 +88,7 @@ struct _GisDriverPrivate {
   GisDriverMode mode;
   UmAccountMode account_mode;
   gboolean small_screen;
+  gboolean hidden;
 
   /* Cancelled on shutdown */
   GCancellable *cancellable;
@@ -340,6 +341,7 @@ gis_driver_show_window (GisDriver *driver)
 {
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
 
+  priv->hidden = FALSE;
   gtk_window_present (priv->main_window);
 }
 
@@ -348,6 +350,7 @@ gis_driver_hide_window (GisDriver *driver)
 {
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
 
+  priv->hidden = TRUE;
   gtk_widget_hide (GTK_WIDGET (priv->main_window));
 }
 
@@ -637,7 +640,8 @@ gis_driver_activate (GApplication *app)
 
   G_APPLICATION_CLASS (gis_driver_parent_class)->activate (app);
 
-  gtk_window_present (GTK_WINDOW (priv->main_window));
+  if (!priv->hidden)
+    gtk_window_present (GTK_WINDOW (priv->main_window));
 }
 
 static gboolean

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -165,12 +165,20 @@ check_live_session (GisDriver   *driver,
 static char *
 get_image_version (void)
 {
+  g_autoptr(GError) error_sysroot = NULL;
+  g_autoptr(GError) error_root = NULL;
   char *image_version =
-    gis_page_util_get_image_version (EOS_IMAGE_VERSION_PATH);
+    gis_page_util_get_image_version (EOS_IMAGE_VERSION_PATH, &error_sysroot);
 
-  if (!image_version)
+  if (image_version == NULL)
     image_version =
-      gis_page_util_get_image_version (EOS_IMAGE_VERSION_ALT_PATH);
+      gis_page_util_get_image_version (EOS_IMAGE_VERSION_ALT_PATH, &error_root);
+
+  if (image_version == NULL)
+    {
+      g_warning ("%s", error_sysroot->message);
+      g_warning ("%s", error_root->message);
+    }
 
   return image_version;
 }

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -101,6 +101,8 @@ gboolean gis_driver_is_in_demo_mode (GisDriver *driver);
 
 gboolean gis_driver_is_live_session (GisDriver *driver);
 
+gboolean gis_driver_is_reformatter (GisDriver *driver);
+
 gboolean gis_driver_is_small_screen (GisDriver *driver);
 
 void gis_driver_add_page (GisDriver *driver,

--- a/gnome-initial-setup/gis-page-util.h
+++ b/gnome-initial-setup/gis-page-util.h
@@ -31,7 +31,8 @@ G_BEGIN_DECLS
 void gis_page_util_show_factory_dialog (GisPage *page);
 void gis_page_util_show_demo_dialog (GisPage *page);
 
-gchar *gis_page_util_get_image_version (const gchar *path);
+gchar *gis_page_util_get_image_version (const gchar *path,
+                                        GError     **error);
 
 G_END_DECLS
 

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -55,6 +55,8 @@ struct _GisLanguagePagePrivate
   GCancellable *cancellable;
 
   GtkAccelGroup *accel_group;
+
+  gboolean checked_unattended_config;
 };
 typedef struct _GisLanguagePagePrivate GisLanguagePagePrivate;
 
@@ -377,6 +379,111 @@ gis_language_page_locale_changed (GisPage *page)
   update_demo_mode_label (self);
 }
 
+/* See https://github.com/endlessm/eos-installer/blob/master/UNATTENDED.md for
+ * full documentation on the reformatter's unattended mode.
+ */
+
+/* On eosinstaller images, a run-mount-eosimages.mount unit is shipped which
+ * arranges for this path to be mounted.
+ */
+#define EOSIMAGES_MOUNT_POINT "/run/mount/eosimages/"
+/* Created by hand, or by hitting Ctrl+U on the last page of the reformatter.
+ * Its mere presence triggers an unattended installation; it may also specify a
+ * locale.
+ */
+#define UNATTENDED_INI_PATH EOSIMAGES_MOUNT_POINT "unattended.ini"
+/* Created by the installer for Windows when it creates a reformatter USB.
+ * Doesn't trigger unattended mode, just pre-selects a UI language.
+ */
+#define INSTALL_INI_PATH EOSIMAGES_MOUNT_POINT "install.ini"
+
+#define LOCALE_GROUP "EndlessOS"
+#define LOCALE_KEY "locale"
+
+/*
+ * check_reformatter_key_file:
+ * @locale: (out): locale specified within @path, or %NULL if none was
+ *  specified.
+ *
+ * Checks whether @path is a valid keyfile, and whether it specifies a locale.
+ *
+ * Returns: %TRUE if @path could be read.
+ */
+static gboolean
+check_reformatter_key_file (const gchar *path,
+                            gchar      **locale)
+{
+  g_autoptr(GKeyFile) key_file = g_key_file_new ();
+  g_autoptr(GError) error = NULL;
+
+  g_return_val_if_fail (locale != NULL, FALSE);
+  g_return_val_if_fail (*locale == NULL, FALSE);
+
+  if (!g_key_file_load_from_file (key_file, path, G_KEY_FILE_NONE, &error))
+    {
+      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        g_warning ("Failed to read %s: %s", path, error->message);
+
+      return FALSE;
+    }
+
+  *locale = g_key_file_get_string (key_file, LOCALE_GROUP, LOCALE_KEY, &error);
+  if (error != NULL &&
+      !g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND) &&
+      !g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+    {
+      g_warning ("Failed to read locale from %s: %s", path, error->message);
+    }
+
+  return TRUE;
+}
+
+static gboolean
+assistant_next_idle_cb (gpointer user_data)
+{
+  gis_assistant_next_page (GIS_ASSISTANT (user_data));
+  return G_SOURCE_REMOVE;
+}
+
+static void
+gis_language_page_shown (GisPage *page)
+{
+  GisLanguagePage *self = GIS_LANGUAGE_PAGE (page);
+  GisLanguagePagePrivate *priv = gis_language_page_get_instance_private (self);
+  gboolean skip_ahead = FALSE;
+  g_autofree gchar *locale = NULL;
+
+  /* For now, only support unattended mode on eosinstaller images. */
+  if (!gis_driver_is_reformatter (page->driver))
+    return;
+
+  /* Only take action once. This prevents an infinite loop if eos-installer
+   * crashes on launch.
+   */
+  if (priv->checked_unattended_config)
+    return;
+
+  priv->checked_unattended_config = TRUE;
+
+  if (check_reformatter_key_file (UNATTENDED_INI_PATH, &locale))
+    skip_ahead = TRUE;
+  else
+    check_reformatter_key_file (INSTALL_INI_PATH, &locale);
+
+  if (locale != NULL)
+    cc_language_chooser_set_language (CC_LANGUAGE_CHOOSER (priv->language_chooser),
+                                      locale);
+
+  if (skip_ahead)
+    {
+      gis_driver_hide_window (page->driver);
+      g_idle_add_full (G_PRIORITY_DEFAULT_IDLE,
+                       assistant_next_idle_cb,
+                       g_object_ref (gis_driver_get_assistant (page->driver)),
+                       g_object_unref);
+    }
+}
+
 static void
 gis_language_page_dispose (GObject *object)
 {
@@ -407,6 +514,7 @@ gis_language_page_class_init (GisLanguagePageClass *klass)
   page_class->page_id = PAGE_ID;
   page_class->locale_changed = gis_language_page_locale_changed;
   page_class->get_accel_group = gis_language_page_get_accel_group;
+  page_class->shown = gis_language_page_shown;
   object_class->constructed = gis_language_page_constructed;
   object_class->dispose = gis_language_page_dispose;
 }

--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
@@ -130,6 +130,9 @@ on_reformatter_exited (GisLiveChooserPage *page,
 
   gis_driver_show_window (driver);
 
+  if (gis_driver_is_reformatter (driver))
+    gis_assistant_previous_page (gis_driver_get_assistant (driver));
+
   if (error != NULL)
     {
       GtkWindow *toplevel = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (page)));
@@ -161,7 +164,7 @@ reformatter_exited_cb (GPid     pid,
 }
 
 static void
-reformat_button_clicked (GisLiveChooserPage *page)
+gis_live_chooser_page_launch_reformatter (GisLiveChooserPage *page)
 {
   g_autoptr(GError) error = NULL;
   GPid pid;
@@ -219,7 +222,7 @@ gis_live_chooser_page_constructed (GObject *object)
 
   g_signal_connect_swapped (priv->reformat_button,
                             "clicked",
-                            G_CALLBACK (reformat_button_clicked),
+                            G_CALLBACK (gis_live_chooser_page_launch_reformatter),
                             page);
 
   g_object_bind_property (driver, "live-dvd", priv->try_label, "visible", G_BINDING_SYNC_CREATE | G_BINDING_INVERT_BOOLEAN);
@@ -247,6 +250,15 @@ gis_live_chooser_page_locale_changed (GisPage *page)
 }
 
 static void
+gis_live_chooser_page_shown (GisPage *page)
+{
+  GisLiveChooserPage *self = GIS_LIVE_CHOOSER_PAGE (page);
+
+  if (gis_driver_is_reformatter (page->driver))
+    gis_live_chooser_page_launch_reformatter (self);
+}
+
+static void
 gis_live_chooser_page_class_init (GisLiveChooserPageClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -255,6 +267,7 @@ gis_live_chooser_page_class_init (GisLiveChooserPageClass *klass)
   page_class->page_id = "live-chooser";
   page_class->locale_changed = gis_live_chooser_page_locale_changed;
   page_class->save_data = gis_live_chooser_page_save_data;
+  page_class->shown = gis_live_chooser_page_shown;
 
   gtk_widget_class_set_template_from_resource (GTK_WIDGET_CLASS (klass), "/org/gnome/initial-setup/gis-live-chooser-page.ui");
 
@@ -281,8 +294,11 @@ gis_live_chooser_page_init (GisLiveChooserPage *page)
 void
 gis_prepare_live_chooser_page (GisDriver *driver)
 {
-  /* Only show this page when running on a live boot session */
-  if (!gis_driver_is_live_session (driver))
+  /* Only include this page when running on live media or as a standalone
+   * reformatter.
+   */
+  if (!gis_driver_is_live_session (driver) &&
+      !gis_driver_is_reformatter (driver))
     return;
 
   gis_driver_add_page (driver,


### PR DESCRIPTION
Historically, eosinstaller images did not include gnome-initial-setup.  Instead, the eos-installer-standalone package installed replacement files to cause gdm to launch eos-installer directly, instead.

This avoided any changes to gnome-initial-setup itself. But unfortunately it introduced its own problems: gnome-initial-setup is moderately coupled to the corresponding versions of gdm and gnome-shell, so eos-installer's copies of the initial-setup session and shell mode had to be manually kept in sync with each GNOME rebase.

Since this was originally implemented, we added support for combined live + installer images, and taught gnome-initial-setup how to launch eos-installer. At this point, it is simpler to include the real gnome-initial-setup in eosinstaller images, too, and make it unconditionally launch eos-installer after the language selection page.  This brings the eosinstaller image closer to the (much more frequently tested) ISOs.

https://phabricator.endlessm.com/T17082

This PR also includes (one half of) a fix for https://phabricator.endlessm.com/T14616, and some fixes for related bugs. https://github.com/endlessm/eos-installer/pull/73 and https://github.com/endlessm/eos-installer/pull/74 are the eos-installer counterparts. All three PRs must be merged at once.