### PR TITLE
Increase default window size

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -707,8 +707,8 @@ update_screen_size (GisDriver *driver)
                                       GTK_POLICY_NEVER,
                                       GTK_POLICY_NEVER);
 
-      size_hints.min_width = size_hints.max_width = 747;
-      size_hints.min_height = size_hints.max_height = 539;
+      size_hints.min_width = size_hints.max_width = 800;
+      size_hints.min_height = size_hints.max_height = 600;
       size_hints.win_gravity = GDK_GRAVITY_CENTER;
 
       gtk_window_set_geometry_hints (priv->main_window,


### PR DESCRIPTION
Let's use more of the available real estate so that we can
fit more options.  For example, this increases the number of
WiFi network options displayed from 3 to 4.

Note that this specification of 800x600 leads to an effective
window size of 748x548.

On future rebases, this can be squashed with
d5b0298d76b9d4dcacf10f98753ae6e0856f8796, where we had
changed from the upstream default of 1024x768.

https://phabricator.endlessm.com/T22165