### PR TITLE
account: Check configuration to hide password switch if needed

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -640,3 +640,13 @@ gis_account_page_local_is_passwordless (GisAccountPageLocal *local)
   GisAccountPageLocalPrivate *priv = gis_account_page_local_get_instance_private (local);
   return priv->passwordless;
 }
+
+void
+gis_account_page_local_show_password_switch (GisAccountPageLocal *local,
+                                             gboolean show_password_switch)
+{
+  GisAccountPageLocalPrivate *priv = gis_account_page_local_get_instance_private (local);
+  /* this hides the label for the password switch too, since their "visible"
+   * properties are bound */
+  gtk_widget_set_visible (priv->password_switch, show_password_switch);
+}

--- a/gnome-initial-setup/pages/account/gis-account-page-local.h
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.h
@@ -53,6 +53,8 @@ gboolean gis_account_page_local_apply (GisAccountPageLocal *local, GisPage *page
 void gis_account_page_local_create_user (GisAccountPageLocal *local);
 void gis_account_page_local_shown (GisAccountPageLocal *local);
 gboolean gis_account_page_local_is_passwordless (GisAccountPageLocal *local);
+void gis_account_page_local_show_password_switch (GisAccountPageLocal *local,
+                                                  gboolean show_password_switch);
 
 G_END_DECLS
 

--- a/gnome-initial-setup/pages/account/gis-account-page-local.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.ui
@@ -158,7 +158,7 @@
             </child>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
+                <property name="visible" bind-source="password_switch" bind-property="visible">True</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Password protected</property>
               </object>


### PR DESCRIPTION
If a vendor wants to have passwordless accounts by default, then they
should be able to set that in the vendor configuration file.
This patch allows that by using the "show-password-switch" option in the
"page.account" group.

https://phabricator.endlessm.com/T23326