### PR TITLE
Abstract how vendor configuration is accessed

### DIFF
--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -116,6 +116,20 @@ void gis_driver_hide_window (GisDriver *driver);
 
 void gis_driver_save_data (GisDriver *driver);
 
+gboolean gis_driver_conf_get_boolean (GisDriver *driver,
+                                      const gchar *group,
+                                      const gchar *key,
+                                      gboolean default_value);
+
+GStrv gis_driver_conf_get_string_list (GisDriver *driver,
+                                       const gchar *group,
+                                       const gchar *key,
+                                       gsize *out_length);
+
+gchar *gis_driver_conf_get_string (GisDriver *driver,
+                                   const gchar *group,
+                                   const gchar *key);
+
 GisDriver *gis_driver_new (GisDriverMode mode);
 
 G_END_DECLS

--- a/gnome-initial-setup/pages/account/gis-account-page.c
+++ b/gnome-initial-setup/pages/account/gis-account-page.c
@@ -109,30 +109,16 @@ on_validation_changed (gpointer        page_area,
 static void
 hide_password_switch_if_needed (GisAccountPage *page)
 {
-  GKeyFile *conf_file = gis_driver_get_vendor_conf_file (GIS_PAGE (page)->driver);
   GisAccountPagePrivate *priv = gis_account_page_get_instance_private (page);
-  g_autoptr(GError) error = NULL;
   gboolean show_password_switch;
 
-  /* do nothing if the configuration file doesn't exist */
-  if (conf_file == NULL)
-    return;
-
   /* check the conf file to see if the password switch should be shown/hidden */
-  show_password_switch = g_key_file_get_boolean (conf_file, CONFIG_ACCOUNT_GROUP,
-                                                 CONFIG_ACCOUNT_SHOW_PASSWORD_SWITCH_KEY,
-                                                 &error);
-  if (error == NULL) {
-    gis_account_page_local_show_password_switch (GIS_ACCOUNT_PAGE_LOCAL (priv->page_local),
-                                                 show_password_switch);
-    return;
-  }
-
-  if (!g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND) &&
-      !g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_GROUP_NOT_FOUND))
-    g_warning ("Couldn't get the value for key '%s' in group [%s]: %s",
-               CONFIG_ACCOUNT_SHOW_PASSWORD_SWITCH_KEY, CONFIG_ACCOUNT_GROUP,
-               error->message);
+  show_password_switch = gis_driver_conf_get_boolean (GIS_PAGE (page)->driver,
+                                                      CONFIG_ACCOUNT_GROUP,
+                                                      CONFIG_ACCOUNT_SHOW_PASSWORD_SWITCH_KEY,
+                                                      TRUE);
+  gis_account_page_local_show_password_switch (GIS_ACCOUNT_PAGE_LOCAL (priv->page_local),
+                                               show_password_switch);
 }
 
 static void

--- a/gnome-initial-setup/pages/branding-welcome/gis-branding-welcome-page.c
+++ b/gnome-initial-setup/pages/branding-welcome/gis-branding-welcome-page.c
@@ -65,8 +65,6 @@ static void
 read_config_file (GisBrandingWelcomePage *page)
 {
   GisBrandingWelcomePagePrivate *priv = NULL;
-  GKeyFile *keyfile = NULL;
-  g_autoptr(GError) error = NULL;
 
   /* VENDOR_CONF_FILE points to a keyfile containing vendor customization
    * options. This code will look for options under the "Welcome" group, and
@@ -85,35 +83,22 @@ read_config_file (GisBrandingWelcomePage *page)
    *     branded edition is about.
    *   logo=/path/to/the/image/with/the/logo.png
    */
-  keyfile = gis_driver_get_vendor_conf_file (GIS_PAGE (page)->driver);
-  if (keyfile == NULL)
-    return;
 
   priv = gis_branding_welcome_page_get_instance_private (page);
 
-  priv->title = g_key_file_get_string (keyfile, VENDOR_BRANDING_WELCOME_GROUP,
-                                       VENDOR_BRANDING_WELCOME_TITLE_KEY, &error);
-  if (priv->title == NULL) {
-    g_warning ("Could not read title for 'Welcome' branding page from %s: %s",
-               VENDOR_CONF_FILE, error->message);
+  priv->title = gis_driver_conf_get_string (GIS_PAGE (page)->driver,
+                                            VENDOR_BRANDING_WELCOME_GROUP,
+                                            VENDOR_BRANDING_WELCOME_TITLE_KEY);
+  if (priv->title == NULL)
     return;
-  }
 
-  priv->description = g_key_file_get_string (keyfile, VENDOR_BRANDING_WELCOME_GROUP,
-                                             VENDOR_BRANDING_WELCOME_DESC_KEY, &error);
-  if (priv->description == NULL) {
-    g_debug ("Could not read description for 'Welcome' branding page from %s: %s",
-             VENDOR_CONF_FILE, error->message);
-    g_clear_error (&error);
-  }
+  priv->description = gis_driver_conf_get_string (GIS_PAGE (page)->driver,
+                                                  VENDOR_BRANDING_WELCOME_GROUP,
+                                                  VENDOR_BRANDING_WELCOME_DESC_KEY);
 
-  priv->logo_path = g_key_file_get_string (keyfile, VENDOR_BRANDING_WELCOME_GROUP,
-                                           VENDOR_BRANDING_WELCOME_LOGO_KEY, &error);
-  if (priv->logo_path == NULL) {
-    g_debug ("Could not read logo path for 'Welcome' branding page from %s: %s",
-             VENDOR_CONF_FILE, error->message);
-    g_clear_error (&error);
-  }
+  priv->logo_path = gis_driver_conf_get_string (GIS_PAGE (page)->driver,
+                                                VENDOR_BRANDING_WELCOME_GROUP,
+                                                VENDOR_BRANDING_WELCOME_LOGO_KEY);
 }
 
 static void


### PR DESCRIPTION
Accessing the vendor configuration is a common need of many pages, so
pages shouldn't have to always deal with the key file directly as it
leads to a lot of repeated code (for error checking and such). This
patch allows that by abstracting the configuration specifics in a few
functions in the GisDriver.

https://phabricator.endlessm.com/T23483