### PR TITLE
build: Add special macro for using libsecret's unstable API

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,7 @@ conf.set('ENABLE_REGION_PAGE', get_option('region-page'))
 conf.set_quoted('LIBEXECDIR', join_paths(prefix, get_option('libexecdir')))
 conf.set_quoted('LOCALSTATEDIR', local_state_dir)
 conf.set_quoted('DEMOVIDEODATADIR', join_paths(data_dir, 'eos-demo-mode'))
+conf.set('SECRET_API_SUBJECT_TO_CHANGE', true)
 
 # Needed for the 'account' page
 cheese_dep = dependency ('cheese',


### PR DESCRIPTION
g-i-s uses libsecret's unstable API, so we need to define the macro
SECRET_API_SUBJECT_TO_CHANGE in order for that API to be included.

This change had been forgotten when we ported the build to Meson.

https://phabricator.endlessm.com/T23515