### PR TITLE
eos-transient-setup: set min-free-space-* to 0

### DIFF
--- a/gnome-initial-setup/eos-transient-setup
+++ b/gnome-initial-setup/eos-transient-setup
@@ -26,7 +26,9 @@ import subprocess
 import sys
 import tempfile
 
-from gi.repository import GLib, Gio
+import gi
+gi.require_version('OSTree', '1.0')
+from gi.repository import GLib, Gio, OSTree  # noqa: E402
 
 log = logging.getLogger(sys.argv[0])
 
@@ -235,6 +237,19 @@ def prepend_installer_to_icon_grid():
             log.exception("while processing %s", path)
 
 
+def reduce_ostree_min_free_space():
+    '''Don't require any free space on disk when installing apps. On live
+    systems, free space is at most half of physical RAM, and running out is not
+    a big deal.'''
+    repo = OSTree.Repo.new_default()
+    repo.open()
+    config = repo.copy_config()
+    # -size alone takes precedence but set both for clarity.
+    config.set_string('core', 'min-free-space-size', '0MB')
+    config.set_integer('core', 'min-free-space-percent', 0)
+    repo.write_config(config)
+
+
 def main():
     """Configures system settings for live or demo sessions."""
     p = argparse.ArgumentParser(description=main.__doc__)
@@ -260,6 +275,7 @@ def main():
 
         disable_chrome_auto_download()
         remove_chrome_from_icon_grids()
+        reduce_ostree_min_free_space()
 
         if mode == Mode.live:
             install_installer_desktop_file()


### PR DESCRIPTION
On live systems, the free "disk" space is, per tmpfs's default, half of
physical RAM. If the system only has 2GB of RAM, then reserving 500MB
(the default) free means there's at 500MB for installing apps. This is
overly restrictive, particularly since it's not such a big deal to run
out of "disk" space on a live system. So, disable this limit.

We have downstream logic in flatpak-dir.c to migrate from setting
-percent to -size. This means that some combinations of these settings
turn out to be "unstable", in the sense that flatpak-dir.c will alter
them whenever the system helper (or root) happens to open the repo:

 -size | -percent | ostree-repo.c      | flatpak-dir.c
------ | -------- | ------------------ | -------------------------------------
 non-0 | *        | -size applies      | no action
 0     | *        | no limit           | no action
 unset | unset    | -percent=3 applies | sets -size to 500MB
 unset | non-0    | -percent applies   | sets -size to 500MB, unsets -percent
 unset | 0        | no limit           | no action

Setting either -size or -percent to zero will do what we want given the
current default configuration; for clarity, just set both. Note that the
units are required for -size.

https://phabricator.endlessm.com/T23552