### PR TITLE
Compile gis-page-util resources

### DIFF
--- a/gnome-initial-setup/meson.build
+++ b/gnome-initial-setup/meson.build
@@ -9,6 +9,12 @@ resources = gnome.compile_resources(
     c_name: 'gis_assistant'
 )
 
+resources += gnome.compile_resources(
+    'gis-page-util-resources',
+    files('gis-page-util.gresource.xml'),
+    c_name: 'gis_page_util'
+)
+
 sources += [
     resources,
     'gnome-initial-setup.c',


### PR DESCRIPTION
The gis-page-util resources had been left out when the project was moved
to meson. As a result doing Ctrl+F for getting the factory dialog didn't
work.

https://phabricator.endlessm.com/T23813