### PR TITLE
Show image version in factory dialog

### DIFF
--- a/gnome-initial-setup/gis-page-util.c
+++ b/gnome-initial-setup/gis-page-util.c
@@ -38,6 +38,7 @@
 #define OSRELEASE_FILE      "/etc/os-release"
 #define SERIAL_VERSION_FILE "/sys/devices/virtual/dmi/id/product_uuid"
 #define DT_COMPATIBLE_FILE  "/proc/device-tree/compatible"
+#define SYSROOT_MOUNT       "/sysroot"
 #define SD_CARD_MOUNT       LOCALSTATEDIR "/endless-extra"
 
 static GtkBuilder *
@@ -369,6 +370,7 @@ gis_page_util_show_factory_dialog (GisPage *page)
   GtkButton *testmode_button;
   GtkDialog *factory_dialog;
   GtkImage *serial_image;
+  GtkLabel *image_version_label;
   GtkLabel *sdcard_label;
   GtkLabel *serial_label;
   GtkLabel *product_id_label;
@@ -377,7 +379,9 @@ gis_page_util_show_factory_dialog (GisPage *page)
   gchar *barcode;
   gchar *barcode_serial, *display_serial;
   gchar *version;
+  gchar *image_version;
   gchar *sd_version = NULL;
+  gchar *image_version_text;
   gchar *sd_text;
   gchar *product_id_text;
 
@@ -390,6 +394,7 @@ gis_page_util_show_factory_dialog (GisPage *page)
   factory_dialog = (GtkDialog *)gtk_builder_get_object (builder, "factory-dialog");
   version_label = (GtkLabel *)gtk_builder_get_object (builder, "software-version");
   product_id_label = (GtkLabel *)gtk_builder_get_object (builder, "product-id");
+  image_version_label = (GtkLabel *)gtk_builder_get_object (builder, "image-version");
   sdcard_label = (GtkLabel *)gtk_builder_get_object (builder, "sd-card");
   serial_label = (GtkLabel *)gtk_builder_get_object (builder, "serial-text");
   serial_image = (GtkImage *)gtk_builder_get_object (builder, "serial-barcode");
@@ -417,6 +422,15 @@ gis_page_util_show_factory_dialog (GisPage *page)
     gtk_widget_set_visible (GTK_WIDGET (serial_label), FALSE);
     gtk_widget_set_visible (GTK_WIDGET (serial_image), FALSE);
   }
+
+  image_version = gis_page_util_get_image_version (SYSROOT_MOUNT, NULL);
+  if (!image_version)
+    sd_version = g_strdup (_("Unknown"));
+
+  image_version_text = g_strdup_printf (_("Image: %s"), image_version);
+  gtk_label_set_text (image_version_label, image_version_text);
+  g_free (image_version);
+  g_free (image_version_text);
 
   if (get_have_sdcard ())
     sd_version = gis_page_util_get_image_version (SD_CARD_MOUNT, NULL);

--- a/gnome-initial-setup/gis-page-util.ui
+++ b/gnome-initial-setup/gis-page-util.ui
@@ -112,6 +112,22 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel" id="image-version">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">image version</property>
+                <attributes>
+                  <attribute name="font-desc" value="default 16"/>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
 	    <child>
               <object class="GtkLabel" id="sd-card">
                 <property name="visible">True</property>


### PR DESCRIPTION
A partner has requested that we provide an indication in this dialog
of which image personality (language) was flashed.

Add the image name stamp to this dialog which includes the
personality name at the end. The same thing was already being
shown for the SD card.

https://phabricator.endlessm.com/T23690