### PR TITLE
timezone: hide by default if location was detected

### DIFF
--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.c
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.c
@@ -439,7 +439,7 @@ gis_timezone_page_constructed (GObject *object)
     gis_driver_conf_get_boolean (GIS_PAGE (page)->driver,
                                  CONFIG_TIMEZONE_GROUP,
                                  CONFIG_TIMEZONE_SHOW_IF_DETECTED_KEY,
-                                 TRUE);
+                                 FALSE);
 
   priv->clock = g_object_new (GNOME_TYPE_WALL_CLOCK, NULL);
   g_signal_connect (priv->clock, "notify::clock", G_CALLBACK (on_clock_changed), page);


### PR DESCRIPTION
Previously, unless the following was specified in the vendor config
file:

    [page.timezone]
    show-if-detected=false

then the timezone selection page would be shown even if the location was
detected via Geoclue.

The argument for skipping the page if location has been detected in some
Endless images is that this makes the FBE process nicer enough to risk
sometimes silently selecting the wrong timezone.  If we believe this for
some users, without any data about how often the wrong timezone is
selected, then we should apply this behaviour for all systems.

This patch switches the default setting to skip the timezone page if
location was detected. The old behaviour can be re-enabled by specifying
the following in the vendor config file:

    [page.timezone]
    show-if-detected=true

https://phabricator.endlessm.com/T23631