### PR TITLE
data: Fix a string matching typo in the polkit rules

### DIFF
--- a/data/20-gnome-initial-setup.rules
+++ b/data/20-gnome-initial-setup.rules
@@ -13,7 +13,7 @@ polkit.addRule(function(action, subject) {
                          action.id === 'com.endlessm.Metrics.SetEnabled' ||
                          action.id === 'com.endlessm.Metrics.ResetTrackingId' ||
                          action.id === 'com.endlessm.TestMode' ||
-                         action.id.indexOf('com.endlessm.DemoMode.' === 0) ||
+                         action.id.indexOf('com.endlessm.DemoMode.') === 0 ||
                          action.id.indexOf('org.freedesktop.hostname1.') === 0 ||
                          action.id.indexOf('org.freedesktop.NetworkManager.') === 0 ||
                          action.id.indexOf('org.freedesktop.locale1.') === 0 ||


### PR DESCRIPTION
This was added in 244f7a745, in 2017, so it evidently hasn’t caused any
problems — but having the bracket in the wrong place was causing
DemoMode action IDs to not be matched here for their initial-setup
polkit fast pass.

Signed-off-by: Philip Withnall <withnall@endlessm.com>