### PR TITLE
Improve timezone detection when connectivity check is slow

### DIFF
--- a/gnome-initial-setup/gis-assistant.c
+++ b/gnome-initial-setup/gis-assistant.c
@@ -201,10 +201,6 @@ set_suggested_action_sensitive (GtkWidget *widget,
                                 gboolean   sensitive)
 {
   gtk_widget_set_sensitive (widget, sensitive);
-  if (sensitive)
-    gtk_style_context_add_class (gtk_widget_get_style_context (widget), "suggested-action");
-  else
-    gtk_style_context_remove_class (gtk_widget_get_style_context (widget), "suggested-action");
 }
 
 static void

--- a/gnome-initial-setup/gis-assistant.ui
+++ b/gnome-initial-setup/gis-assistant.ui
@@ -48,6 +48,9 @@
       <object class="GtkButton" id="forward">
         <property name="use-underline">True</property>
         <property name="can-default">True</property>
+        <style>
+          <class name="suggested-action"/>
+        </style>
       </object>
       <packing>
         <property name="pack-type">end</property>

--- a/gnome-initial-setup/pages/site/gis-site-page.c
+++ b/gnome-initial-setup/pages/site/gis-site-page.c
@@ -288,7 +288,8 @@ parse_sites_file (const gchar *filename)
   json_parser_load_from_file (parser, filename, &error);
   if (error)
     {
-      g_warning ("Unable to parse `%s': %s", filename, error->message);
+      if (!g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        g_warning ("Unable to parse ‘%s’: %s", filename, error->message);
       g_error_free (error);
       goto out;
     }

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.ui
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.ui
@@ -85,6 +85,9 @@
                         <property name="halign">center</property>
                         <property name="valign">center</property>
                       </object>
+                      <packing>
+                        <property name="pass-through">True</property>
+                      </packing>
                     </child>
                   </object>
                 </child>


### PR DESCRIPTION
If we have already retrieved a location from the network when it comes time to show the timezone page, we skip it entirely. But in practice, it is quite easy to reach the timezone page before the location has been retrieved, even after configuring a wireless network.

On the network page, we would previously change the grey **Skip** button to a blue **Next** button as soon as the network connection came up. But GeoClue waits for NM's connectivity check to succeed before requesting location from the network. Even on a good network, the connectivity check (a simple HTTP request to a Linode VM) may be essentially instantaneous, or may take a few hundred milliseconds, or may take 10 seconds or more. Tweak this page to wait for the connectivity check to finish (or for a timeout, whichever comes first) before changing **Skip** to **Next**.

The timezone page would previously cancel the GeoClue location request if it was displayed before a reply was received. Tweak this to only cancel the GeoClue request if the user interacts with the search box or map. This improves the situation where the connectivity check takes a long time: although the user may still see the timezone page, they at least might not have to do anything more than wait a moment then click Next. The page already shows this string:

> The time zone will be set automatically if your location can be found.

So there is no need for a string change to explain this new behaviour.

I also noticed that it's a one-line change to fix a longstanding issue, namely that it's impossible to click on London because the overlay obscures it.

The other two patches on this PR have no user-visible impact.

https://phabricator.endlessm.com/T23524