### PR TITLE
eos-transient-setup: Add file-db path for dconf defaults from OSTree

### DIFF
--- a/gnome-initial-setup/eos-transient-setup
+++ b/gnome-initial-setup/eos-transient-setup
@@ -49,6 +49,7 @@ USER_PROFILE_PATH = '/usr/local/share/dconf/profile/user'
 USER_PROFILE = '''user-db:user
 file-db:/var/lib/eos-image-defaults/settings.live
 file-db:/var/lib/eos-image-defaults/settings
+file-db:/usr/share/eos-default-settings/settings
 '''
 
 SHELL_SCHEMA = 'org.gnome.shell'


### PR DESCRIPTION
This has recently been added to the normal user profile in
eos-theme.git, so should be added here too so that the demo/live
sessions have the same set of default dconf settings as the normal
sessions.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20990