### PR TITLE
Connect to GDM as soon as gnome-initial-setup starts

### DIFF
--- a/gnome-initial-setup/pages/summary/gis-summary-page.c
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.c
@@ -78,6 +78,7 @@ connect_to_gdm (GdmGreeter      **greeter,
     g_error_free (error);
   }
 
+  g_clear_object (&client);
   return;
 }
 
@@ -176,7 +177,7 @@ static void
 log_user_in (GisSummaryPage *page)
 {
   GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (page);
-  GError *error = NULL;
+  g_autoptr(GError) error = NULL;
 
   if (!priv->greeter || !priv->user_verifier) {
     g_warning ("No GDM connection; not initiating login");

--- a/gnome-initial-setup/pages/summary/gis-summary-page.c
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.c
@@ -50,6 +50,9 @@ struct _GisSummaryPagePrivate {
   ActUser *user_account;
   const gchar *user_password;
 
+  GdmGreeter *greeter;
+  GdmUserVerifier *user_verifier;
+
   GDBusProxy *clippy_proxy;
   gulong clippy_proxy_signal_id;
 };
@@ -57,34 +60,25 @@ typedef struct _GisSummaryPagePrivate GisSummaryPagePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (GisSummaryPage, gis_summary_page, GIS_TYPE_PAGE);
 
-static gboolean
+static void
 connect_to_gdm (GdmGreeter      **greeter,
                 GdmUserVerifier **user_verifier)
 {
   GdmClient *client;
-
   GError *error = NULL;
-  gboolean res = FALSE;
 
   client = gdm_client_new ();
 
   *greeter = gdm_client_get_greeter_sync (client, NULL, &error);
-  if (error != NULL)
-    goto out;
+  if (error == NULL)
+    *user_verifier = gdm_client_get_user_verifier_sync (client, NULL, &error);
 
-  *user_verifier = gdm_client_get_user_verifier_sync (client, NULL, &error);
-  if (error != NULL)
-    goto out;
-
-  res = TRUE;
-
- out:
   if (error != NULL) {
     g_warning ("Failed to open connection to GDM: %s", error->message);
     g_error_free (error);
   }
 
-  return res;
+  return;
 }
 
 static void
@@ -183,24 +177,22 @@ log_user_in (GisSummaryPage *page)
 {
   GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (page);
   GError *error = NULL;
-  GdmGreeter *greeter;
-  GdmUserVerifier *user_verifier;
 
-  if (!connect_to_gdm (&greeter, &user_verifier)) {
+  if (!priv->greeter || !priv->user_verifier) {
     g_warning ("No GDM connection; not initiating login");
     return;
   }
 
-  g_signal_connect (user_verifier, "info",
+  g_signal_connect (priv->user_verifier, "info",
                     G_CALLBACK (on_info), page);
-  g_signal_connect (user_verifier, "problem",
+  g_signal_connect (priv->user_verifier, "problem",
                     G_CALLBACK (on_problem), page);
-  g_signal_connect (user_verifier, "info-query",
+  g_signal_connect (priv->user_verifier, "info-query",
                     G_CALLBACK (on_info_query), page);
-  g_signal_connect (user_verifier, "secret-info-query",
+  g_signal_connect (priv->user_verifier, "secret-info-query",
                     G_CALLBACK (on_secret_info_query), page);
 
-  g_signal_connect (greeter, "session-opened",
+  g_signal_connect (priv->greeter, "session-opened",
                     G_CALLBACK (on_session_opened), page);
 
   /* We are in NEW_USER mode and we want to make it possible for third
@@ -208,7 +200,7 @@ log_user_in (GisSummaryPage *page)
    */
   add_uid_file (act_user_get_uid (priv->user_account));
 
-  gdm_user_verifier_call_begin_verification_for_user_sync (user_verifier,
+  gdm_user_verifier_call_begin_verification_for_user_sync (priv->user_verifier,
                                                            SERVICE_NAME,
                                                            act_user_get_user_name (priv->user_account),
                                                            NULL, &error);
@@ -481,6 +473,8 @@ gis_summary_page_constructed (GObject *object)
       gtk_widget_set_margin_end (priv->start_button_label, 12);
     }
 
+  connect_to_gdm (&priv->greeter, &priv->user_verifier);
+
   gtk_widget_show (GTK_WIDGET (page));
 }
 
@@ -500,6 +494,18 @@ gis_summary_page_finalize (GObject *object)
   g_clear_object (&priv->clippy_proxy);
 
   G_OBJECT_CLASS (gis_summary_page_parent_class)->finalize (object);
+}
+
+static void
+gis_summary_page_dispose (GObject *object)
+{
+  GisSummaryPage *page = GIS_SUMMARY_PAGE (object);
+  GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (page);
+
+  g_clear_object (&priv->greeter);
+  g_clear_object (&priv->user_verifier);
+
+  G_OBJECT_CLASS (gis_summary_page_parent_class)->dispose (object);
 }
 
 static void
@@ -529,6 +535,7 @@ gis_summary_page_class_init (GisSummaryPageClass *klass)
   page_class->shown = gis_summary_page_shown;
   object_class->constructed = gis_summary_page_constructed;
   object_class->finalize = gis_summary_page_finalize;
+  object_class->dispose = gis_summary_page_dispose;
 }
 
 static void


### PR DESCRIPTION
GDM can't tell Plymouth to quit until gnome-initial-setup connects to
it, so GDM knows gnome-initial-setup has started successfully. Currently
gnome-initial-setup only connects to GDM once the user clicks the "Start
Using $DISTRO" button on the last page, to switch over to the
newly-created user. This prevents accessing the TTY for the whole time
gnome-initial-setup is running and makes systemd account the time spent
in gnome-initial-setup as part of the boot process.

Connecting to GDM as soon as gnome-initial-setup starts allows GDM to
tell Plymouth to quit at the right time, avoiding the problems described
above.

https://phabricator.endlessm.com/T21181
