### PR TITLE
driver: Connect to GDM as soon as g-i-s starts

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -25,6 +25,7 @@
 
 #include <stdlib.h>
 #include <locale.h>
+#include <gdm/gdm-client.h>
 
 #include "gis-assistant.h"
 #include "gis-page-util.h"
@@ -74,6 +75,10 @@ static GParamSpec *obj_props[PROP_LAST];
 struct _GisDriverPrivate {
   GtkWindow *main_window;
   GisAssistant *assistant;
+
+  GdmClient *client;
+  GdmGreeter *greeter;
+  GdmUserVerifier *user_verifier;
 
   ActUser *user_account;
   gchar *user_password;
@@ -241,6 +246,19 @@ image_is_reformatter (const gchar *image_version)
 }
 
 static void
+gis_driver_dispose (GObject *object)
+{
+  GisDriver *driver = GIS_DRIVER (object);
+  GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
+
+  g_clear_object (&priv->user_verifier);
+  g_clear_object (&priv->greeter);
+  g_clear_object (&priv->client);
+
+  G_OBJECT_CLASS (gis_driver_parent_class)->dispose (object);
+}
+
+static void
 gis_driver_finalize (GObject *object)
 {
   GisDriver *driver = GIS_DRIVER (object);
@@ -368,6 +386,22 @@ gis_driver_get_account_mode (GisDriver *driver)
 {
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
   return priv->account_mode;
+}
+
+gboolean
+gis_driver_get_gdm_objects (GisDriver        *driver,
+                            GdmGreeter      **greeter,
+                            GdmUserVerifier **user_verifier)
+{
+  GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
+
+  if (priv->greeter == NULL || priv->user_verifier == NULL)
+    return FALSE;
+
+  *greeter = priv->greeter;
+  *user_verifier = priv->user_verifier;
+
+  return TRUE;
 }
 
 void
@@ -905,6 +939,26 @@ emit_startup_sound (GApplication * app, gpointer user_data)
 }
 
 static void
+connect_to_gdm (GisDriver *driver)
+{
+  GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
+  g_autoptr(GError) error = NULL;
+
+  priv->client = gdm_client_new ();
+
+  priv->greeter = gdm_client_get_greeter_sync (priv->client, NULL, &error);
+  if (error != NULL)
+    priv->user_verifier = gdm_client_get_user_verifier_sync (priv->client, NULL, &error);
+
+  if (error != NULL) {
+    g_warning ("Failed to open connection to GDM: %s", error->message);
+    g_clear_object (&priv->user_verifier);
+    g_clear_object (&priv->greeter);
+    g_clear_object (&priv->client);
+  }
+}
+
+static void
 gis_driver_startup (GApplication *app)
 {
   GisDriver *driver = GIS_DRIVER (app);
@@ -912,6 +966,9 @@ gis_driver_startup (GApplication *app)
   g_autofree char *image_version = NULL;
 
   G_APPLICATION_CLASS (gis_driver_parent_class)->startup (app);
+
+  if (priv->mode == GIS_DRIVER_MODE_NEW_USER)
+    connect_to_gdm (driver);
 
   priv->main_window = g_object_new (GTK_TYPE_APPLICATION_WINDOW,
                                     "application", app,
@@ -991,6 +1048,7 @@ gis_driver_class_init (GisDriverClass *klass)
 
   gobject_class->get_property = gis_driver_get_property;
   gobject_class->set_property = gis_driver_set_property;
+  gobject_class->dispose = gis_driver_dispose;
   gobject_class->finalize = gis_driver_finalize;
   application_class->startup = gis_driver_startup;
   application_class->activate = gis_driver_activate;

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -25,6 +25,7 @@
 #include "gis-assistant.h"
 #include "gis-page.h"
 #include <act/act-user-manager.h>
+#include <gdm/gdm-client.h>
 
 G_BEGIN_DECLS
 
@@ -88,6 +89,10 @@ const gchar *gis_driver_get_user_language (GisDriver   *driver);
 void gis_driver_set_username (GisDriver   *driver,
                               const gchar *username);
 const gchar *gis_driver_get_username (GisDriver *driver);
+
+gboolean gis_driver_get_gdm_objects (GisDriver        *driver,
+                                     GdmGreeter      **greeter,
+                                     GdmUserVerifier **user_verifier);
 
 GisDriverMode gis_driver_get_mode (GisDriver *driver);
 

--- a/gnome-initial-setup/pages/summary/gis-summary-page.c
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.c
@@ -50,9 +50,6 @@ struct _GisSummaryPagePrivate {
   ActUser *user_account;
   const gchar *user_password;
 
-  GdmGreeter *greeter;
-  GdmUserVerifier *user_verifier;
-
   GDBusProxy *clippy_proxy;
   gulong clippy_proxy_signal_id;
 };
@@ -60,26 +57,35 @@ typedef struct _GisSummaryPagePrivate GisSummaryPagePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (GisSummaryPage, gis_summary_page, GIS_TYPE_PAGE);
 
-static void
+static gboolean
 connect_to_gdm (GdmGreeter      **greeter,
                 GdmUserVerifier **user_verifier)
 {
   GdmClient *client;
+
   GError *error = NULL;
+  gboolean res = FALSE;
 
   client = gdm_client_new ();
 
   *greeter = gdm_client_get_greeter_sync (client, NULL, &error);
-  if (error == NULL)
-    *user_verifier = gdm_client_get_user_verifier_sync (client, NULL, &error);
+  if (error != NULL)
+    goto out;
 
+  *user_verifier = gdm_client_get_user_verifier_sync (client, NULL, &error);
+  if (error != NULL)
+    goto out;
+
+  res = TRUE;
+
+ out:
   if (error != NULL) {
     g_warning ("Failed to open connection to GDM: %s", error->message);
     g_error_free (error);
   }
 
   g_clear_object (&client);
-  return;
+  return res;
 }
 
 static void
@@ -178,22 +184,24 @@ log_user_in (GisSummaryPage *page)
 {
   GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (page);
   g_autoptr(GError) error = NULL;
+  GdmGreeter *greeter;
+  GdmUserVerifier *user_verifier;
 
-  if (!priv->greeter || !priv->user_verifier) {
+  if (!connect_to_gdm (&greeter, &user_verifier)) {
     g_warning ("No GDM connection; not initiating login");
     return;
   }
 
-  g_signal_connect (priv->user_verifier, "info",
+  g_signal_connect (user_verifier, "info",
                     G_CALLBACK (on_info), page);
-  g_signal_connect (priv->user_verifier, "problem",
+  g_signal_connect (user_verifier, "problem",
                     G_CALLBACK (on_problem), page);
-  g_signal_connect (priv->user_verifier, "info-query",
+  g_signal_connect (user_verifier, "info-query",
                     G_CALLBACK (on_info_query), page);
-  g_signal_connect (priv->user_verifier, "secret-info-query",
+  g_signal_connect (user_verifier, "secret-info-query",
                     G_CALLBACK (on_secret_info_query), page);
 
-  g_signal_connect (priv->greeter, "session-opened",
+  g_signal_connect (greeter, "session-opened",
                     G_CALLBACK (on_session_opened), page);
 
   /* We are in NEW_USER mode and we want to make it possible for third
@@ -201,7 +209,7 @@ log_user_in (GisSummaryPage *page)
    */
   add_uid_file (act_user_get_uid (priv->user_account));
 
-  gdm_user_verifier_call_begin_verification_for_user_sync (priv->user_verifier,
+  gdm_user_verifier_call_begin_verification_for_user_sync (user_verifier,
                                                            SERVICE_NAME,
                                                            act_user_get_user_name (priv->user_account),
                                                            NULL, &error);
@@ -475,8 +483,6 @@ gis_summary_page_constructed (GObject *object)
       gtk_widget_set_margin_end (priv->start_button_label, 12);
     }
 
-  connect_to_gdm (&priv->greeter, &priv->user_verifier);
-
   gtk_widget_show (GTK_WIDGET (page));
 }
 
@@ -496,18 +502,6 @@ gis_summary_page_finalize (GObject *object)
   g_clear_object (&priv->clippy_proxy);
 
   G_OBJECT_CLASS (gis_summary_page_parent_class)->finalize (object);
-}
-
-static void
-gis_summary_page_dispose (GObject *object)
-{
-  GisSummaryPage *page = GIS_SUMMARY_PAGE (object);
-  GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (page);
-
-  g_clear_object (&priv->greeter);
-  g_clear_object (&priv->user_verifier);
-
-  G_OBJECT_CLASS (gis_summary_page_parent_class)->dispose (object);
 }
 
 static void
@@ -537,7 +531,6 @@ gis_summary_page_class_init (GisSummaryPageClass *klass)
   page_class->shown = gis_summary_page_shown;
   object_class->constructed = gis_summary_page_constructed;
   object_class->finalize = gis_summary_page_finalize;
-  object_class->dispose = gis_summary_page_dispose;
 }
 
 static void

--- a/gnome-initial-setup/pages/summary/gis-summary-page.c
+++ b/gnome-initial-setup/pages/summary/gis-summary-page.c
@@ -57,37 +57,6 @@ typedef struct _GisSummaryPagePrivate GisSummaryPagePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (GisSummaryPage, gis_summary_page, GIS_TYPE_PAGE);
 
-static gboolean
-connect_to_gdm (GdmGreeter      **greeter,
-                GdmUserVerifier **user_verifier)
-{
-  GdmClient *client;
-
-  GError *error = NULL;
-  gboolean res = FALSE;
-
-  client = gdm_client_new ();
-
-  *greeter = gdm_client_get_greeter_sync (client, NULL, &error);
-  if (error != NULL)
-    goto out;
-
-  *user_verifier = gdm_client_get_user_verifier_sync (client, NULL, &error);
-  if (error != NULL)
-    goto out;
-
-  res = TRUE;
-
- out:
-  if (error != NULL) {
-    g_warning ("Failed to open connection to GDM: %s", error->message);
-    g_error_free (error);
-  }
-
-  g_clear_object (&client);
-  return res;
-}
-
 static void
 request_info_query (GisSummaryPage  *page,
                     GdmUserVerifier *user_verifier,
@@ -184,10 +153,11 @@ log_user_in (GisSummaryPage *page)
 {
   GisSummaryPagePrivate *priv = gis_summary_page_get_instance_private (page);
   g_autoptr(GError) error = NULL;
-  GdmGreeter *greeter;
-  GdmUserVerifier *user_verifier;
+  GdmGreeter *greeter = NULL;
+  GdmUserVerifier *user_verifier = NULL;
 
-  if (!connect_to_gdm (&greeter, &user_verifier)) {
+  if (!gis_driver_get_gdm_objects (GIS_PAGE (page)->driver,
+                                   &greeter, &user_verifier)) {
     g_warning ("No GDM connection; not initiating login");
     return;
   }


### PR DESCRIPTION
GDM can't tell Plymouth to quit until g-i-s connects to it, so GDM knows
g-i-s has started successfully. Currently g-i-s only connects to GDM on
the last page, when it logs-in the new user. This prevents accessing the
TTY and makes systemd account the time spent in g-i-s as part of the
boot process.

Connecting to GDM as soon as g-i-s allows GDM to tell Plymouth to quit
at the right time, avoiding the problems described above.

Closes: https://gitlab.gnome.org/GNOME/gdm/issues/439

https://phabricator.endlessm.com/T21181