### PR TITLE
driver: fix sense of error check when connecting to GDM

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -947,7 +947,7 @@ connect_to_gdm (GisDriver *driver)
   priv->client = gdm_client_new ();
 
   priv->greeter = gdm_client_get_greeter_sync (priv->client, NULL, &error);
-  if (error != NULL)
+  if (error == NULL)
     priv->user_verifier = gdm_client_get_user_verifier_sync (priv->client, NULL, &error);
 
   if (error != NULL) {


### PR DESCRIPTION
JP's original patch was correct, but I amended
7383c717fd13ca418dd0b97d3a4dedb0dbd1dd65 to change "!error" to a
comparison to "NULL". Unfortunately I got the comparison backwards.

https://phabricator.endlessm.com/T21181