### PR TITLE
Ensure shared user doesn't collide with administrator

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -43,9 +43,6 @@
 
 #define VALIDATION_TIMEOUT 600
 
-#define SHARED_ACCOUNT_USERNAME "shared"
-#define SHARED_ACCOUNT_FULLNAME "Shared Account"
-
 #define CONFIG_ACCOUNT_GROUP "page.account"
 #define CONFIG_ACCOUNT_DEFAULT_AVATAR_KEY "default-avatar"
 

--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -585,11 +585,10 @@ static void
 local_create_user (GisAccountPageLocal *page)
 {
   GisAccountPageLocalPrivate *priv = gis_account_page_local_get_instance_private (page);
-  GisDriver *driver;
+  GisDriver *driver = GIS_DRIVER (g_application_get_default ());
   const gchar *username;
   const gchar *fullname;
   GError *error = NULL;
-
 
   username = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (priv->username_combo));
   fullname = gtk_entry_get_text (GTK_ENTRY (priv->fullname_entry));
@@ -614,7 +613,6 @@ local_create_user (GisAccountPageLocal *page)
 
   g_signal_emit (page, signals[USER_CREATED], 0, priv->act_user, "");
 
-  driver = GIS_DRIVER (g_application_get_default ());
 
   if (!gis_driver_is_hack (driver))
     create_shared_user (page);

--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -593,10 +593,6 @@ local_create_user (GisAccountPageLocal *page)
   const gchar *fullname;
   GError *error = NULL;
 
-  driver = GIS_DRIVER (g_application_get_default ());
-
-  if (!gis_driver_is_hack (driver))
-    create_shared_user (page);
 
   username = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (priv->username_combo));
   fullname = gtk_entry_get_text (GTK_ENTRY (priv->fullname_entry));
@@ -620,6 +616,11 @@ local_create_user (GisAccountPageLocal *page)
     act_user_set_automatic_login (priv->act_user, TRUE);
 
   g_signal_emit (page, signals[USER_CREATED], 0, priv->act_user, "");
+
+  driver = GIS_DRIVER (g_application_get_default ());
+
+  if (!gis_driver_is_hack (driver))
+    create_shared_user (page);
 }
 
 static void

--- a/gnome-initial-setup/pages/account/gis-account-page.c
+++ b/gnome-initial-setup/pages/account/gis-account-page.c
@@ -258,8 +258,6 @@ on_shared_user_created (GtkWidget       *page_local,
     language = gis_driver_get_user_language (GIS_PAGE (page)->driver);
     if (language)
         act_user_set_language (user, language);
-
-    gis_driver_set_user_permissions (GIS_PAGE (page)->driver, user, password);
 }
 
 static void

--- a/gnome-initial-setup/pages/account/um-utils.c
+++ b/gnome-initial-setup/pages/account/um-utils.c
@@ -172,6 +172,10 @@ is_username_used (const gchar *username)
                 return FALSE;
         }
 
+        if (strcmp (username, SHARED_ACCOUNT_USERNAME) == 0) {
+                return TRUE;
+        }
+
         pwent = getpwnam (username);
 
         return pwent != NULL;

--- a/gnome-initial-setup/pages/account/um-utils.h
+++ b/gnome-initial-setup/pages/account/um-utils.h
@@ -27,6 +27,13 @@
 
 G_BEGIN_DECLS
 
+/* Endless-specific: username and full name for the built-in shared account, an
+ * unprivileged, passwordless user created after the administrator account on
+ * most images.
+ */
+#define SHARED_ACCOUNT_USERNAME "shared"
+#define SHARED_ACCOUNT_FULLNAME "Shared Account"
+
 void     set_entry_validation_error       (GtkEntry    *entry,
                                            const gchar *text);
 void     set_entry_validation_checkmark   (GtkEntry    *entry);


### PR DESCRIPTION
We get sporadic reports of systems which only have the shared user, and no administrator user. (In one case, the user reported not being asked to create an admin user during the FBE.) It's hard to recover from this state because the shared user is not an administrator and the root account is locked; it's also hard to get useful logs, because the shared user cannot read the full journal.

I found one way to reproduce this problem: enter "shared" when prompted for your full name. Previously, this would generate "shared" as your username; because the hardcoded shared account was created before the user's own account, creating the administrator account (with the same username) would fail, and you'd be stuck with >= 1 non-system user (meaning the FBE will not run on boot) but no administrators.

It seems a little unlikely that non-English-speaking users entered the name "shared", but I couldn't find any other ways to get into this situation. In any case, here are 3 related fixes:

* Create the shared user only if creating the administrator user succeeds
* Don't generate "shared" as a candidate username for the administrator user
* Don't temporarily store the shared user's credentials to use to sign in at the end of the FBE

With these changes, if a user does find whatever other way there is to cause the administrator account not to be created, the shared user will also not be created, and the FBE will run at the next reboot.

https://phabricator.endlessm.com/T19500