### PR TITLE
Unlock keyring using libsecret + internal D-Bus API

### DIFF
--- a/gnome-initial-setup/gnome-initial-setup-copy-worker.c
+++ b/gnome-initial-setup/gnome-initial-setup-copy-worker.c
@@ -6,7 +6,6 @@
 #include <pwd.h>
 #include <string.h>
 #include <gio/gio.h>
-#include <gnome-keyring.h>
 #include <stdlib.h>
 
 static char *
@@ -66,23 +65,6 @@ move_file_from_homedir (GFile       *src_base,
   }
 }
 
-static void
-unlock_keyring (const gchar *initial_setup_homedir)
-{
-  gchar *file;
-  gchar *password = NULL;
-
-  file = g_build_filename (initial_setup_homedir, ".config/password", NULL);
-  if (g_file_get_contents (file, &password, NULL, NULL))
-    gnome_keyring_unlock_sync ("login", password);
-  else
-    g_warning ("Unable to read user password file");
-
-  g_remove (file);
-  g_free (file);
-  g_free (password);
-}
-
 int
 main (int    argc,
       char **argv)
@@ -113,8 +95,6 @@ main (int    argc,
   FILE (".config/goa-1.0/accounts.conf");
   FILE (".config/monitors.xml");
   FILE (".local/share/keyrings/login.keyring");
-
-  unlock_keyring (initial_setup_homedir);
 
   return EXIT_SUCCESS;
 }

--- a/gnome-initial-setup/meson.build
+++ b/gnome-initial-setup/meson.build
@@ -49,7 +49,6 @@ dependencies = [
     dependency ('gio-unix-2.0', version: '>= 2.53.0'),
     dependency ('gdm', version: '>= 3.8.3'),
     dependency ('geocode-glib-1.0'),
-    dependency ('gnome-keyring-1'),
     dependency ('libgeoclue-2.0', version: '>= 2.3.1'),
     cc.find_library('m', required: false),
     dependency ('pango', version: '>= 1.32.5'),


### PR DESCRIPTION
libgnome-keyring has been dropped from Debian in favour of applications
using libsecret.
<https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892359>

libsecret does not provide a straightforward API to unlock a keyring
with a given passphrase, but we can do it with gnome-keyring's
InternalUnsupportedGuiltRiddenInterface, which gis-keyring.c uses to set
the passphrase on the login keyring in the first place.

This should be squashed into 'copy-worker: Unlock keyring on first
login' in the next rebase.

https://phabricator.endlessm.com/T26274