### PR TITLE
Drop libgnome-keyring dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-initial-setup (3.28.0-0endless2) unstable; urgency=medium
+
+  * Drop libgnome-keyring dependency (T26274).
+
+ -- Will Thompson <wjt@endlessm.com>  Thu, 25 Apr 2019 13:52:13 +0100
+
 gnome-initial-setup (3.28.0-0endless1) unstable; urgency=medium
 
   * New version rebased on upstream stable

--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,6 @@ Build-Depends: debhelper (>= 11),
                eos-metrics-0-dev (>= 0.5.0),
                libattr1-dev,
                libevince-dev,
-               libgnome-keyring-dev,
                meson (>= 0.47),
                zint-devel,
 Standards-Version: 4.1.2

--- a/debian/control.in
+++ b/debian/control.in
@@ -34,7 +34,6 @@ Build-Depends: debhelper (>= 11),
                eos-metrics-0-dev (>= 0.5.0),
                libattr1-dev,
                libevince-dev,
-               libgnome-keyring-dev,
                meson (>= 0.47),
                zint-devel,
 Standards-Version: 4.1.2


### PR DESCRIPTION
This library has been removed from Debian; we have reimplemented our
downstream code that used it in terms of libsecret and an internal
gnome-keyring D-Bus API.

Counterpart to #282.

https://phabricator.endlessm.com/T26274