### PR TITLE
Allow gnome-initial-setup user to run eos-write-location

### DIFF
--- a/data/20-gnome-initial-setup.rules
+++ b/data/20-gnome-initial-setup.rules
@@ -23,6 +23,11 @@ polkit.addRule(function(action, subject) {
                          action.id.indexOf('org.freedesktop.realmd.') === 0 ||
                          action.id.indexOf('org.freedesktop.RealtimeKit1.') === 0);
 
+    if (action.id === 'org.freedesktop.policykit.exec' &&
+            action.lookup('program') === '/usr/lib/gnome-initial-setup/eos-write-location') {
+        actionMatches = true;
+    }
+
     if (actionMatches) {
         if (subject.local)
             return 'yes';


### PR DESCRIPTION
This is necessary in order for the Site page to be able to save its data
to /etc/metrics/location.conf.

https://phabricator.endlessm.com/T27787