### PR TITLE
Fixes for site page

### DIFF
--- a/data/20-gnome-initial-setup.rules
+++ b/data/20-gnome-initial-setup.rules
@@ -24,6 +24,11 @@ polkit.addRule(function(action, subject) {
                          action.id.indexOf('org.freedesktop.RealtimeKit1.') === 0);
 
     if (action.id === 'org.freedesktop.policykit.exec' &&
+            action.lookup('program') === '/usr/lib/gnome-initial-setup/eos-write-location') {
+        actionMatches = true;
+    }
+
+    if (action.id === 'org.freedesktop.policykit.exec' &&
         action.lookup('program') === '/usr/lib/gnome-initial-setup/eos-setup-live-user') {
       actionMatches = true;
     }

--- a/po/es.po
+++ b/po/es.po
@@ -14,15 +14,15 @@
 # Nuritzi Sanchez <ns@endlessm.com>, 2014,2016-2017
 # Philip Chimento <philip.chimento@gmail.com>, 2014
 # Roddy Shuler <roddy@stanfordalumni.org>, 2014-2015,2017-2018
-# Travis Reitter <travis.reitter@endlessm.com>, 2018
+# Travis Reitter <travis.reitter@endlessm.com>, 2018-2019
 # Will Thompson <wjt@endlessm.com>, 2019
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-initial-setup\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-07 15:00+0000\n"
-"PO-Revision-Date: 2019-01-07 17:27+0000\n"
-"Last-Translator: Will Thompson <wjt@endlessm.com>\n"
+"PO-Revision-Date: 2019-09-16 22:56+0000\n"
+"Last-Translator: Travis Reitter <travis.reitter@endlessm.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/endless-os/gnome-initial-setup/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -715,13 +715,13 @@ msgstr "Elige tu país o región."
 
 #: gnome-initial-setup/pages/site/gis-site-page.ui:33
 msgid "Site"
-msgstr "Sitio"
+msgstr "Clave del centro de trabajo"
 
 #: gnome-initial-setup/pages/site/gis-site-page.ui:54
 msgid ""
 "At which site is this computer located? Search for your site here. You may "
 "enter manually if there is no match."
-msgstr "¿En que sitio se encuentra esta computadora?. Busca tu sitio aquí, si no lo encuentras, puedes escribir su nombre manualmente."
+msgstr "¿En que centro de trabajo se encuentra esta computadora?\nBuscalo aquí; si no lo encuentras, escríbelo manualmente.\n\nNota: Es importante capturar correctamente el centro de trabajo pues no se podrá modificar posteriormente."
 
 #: gnome-initial-setup/pages/site/gis-site-page.ui:78
 msgid "enter manually"


### PR DESCRIPTION
Two backports from master, both manually applied/resolved:

* Allow gnome-initial-setup user to run eos-write-location
* Backport site page Spanish translation updates

https://phabricator.endlessm.com/T27733
https://phabricator.endlessm.com/T27787