### PR TITLE
assistant: mark "Accept" button as suggested action

### DIFF
--- a/gnome-initial-setup/gis-assistant.ui
+++ b/gnome-initial-setup/gis-assistant.ui
@@ -60,6 +60,9 @@
       <object class="GtkButton" id="accept">
         <property name="use-underline">True</property>
         <property name="can-default">True</property>
+        <style>
+          <class name="suggested-action"/>
+        </style>
       </object>
       <packing>
         <property name="pack-type">end</property>


### PR DESCRIPTION
3857805 added this style class to the "Next" button, and removed code
that would set this class depending on whether the widget is sensitive.
At the time I overlooked that the suggested-action style class should
also be present for the "Accept" button on the EULA page: I think it's
correct to say that accepting the EULA is the suggested action.

There is a third button which may appear in this position: "Skip". This
is used (for example) on the Wi-Fi configuration page when no network is
selected. It's correct not to mark this button as suggested: the
suggested action is to configure a Wi-Fi network.

https://gitlab.gnome.org/GNOME/gnome-initial-setup/merge_requests/61
https://phabricator.endlessm.com/T27790