### PR TITLE
live-chooser: don't create live user account when in persistent live …

### DIFF
--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
@@ -65,6 +65,9 @@ gis_live_chooser_page_save_data (GisPage *page)
   g_autoptr(GError) error = NULL;
   const gchar *language;
 
+  if (gis_driver_has_live_persistence (page->driver))
+    return;
+
   error = NULL;
   user = act_user_manager_create_user (priv->act_client,
                                        LIVE_ACCOUNT_USERNAME,


### PR DESCRIPTION
…mode

Recent changes add support for persistent live mode, where the full
series of setup steps are shown, including user creation.

When running in that mode, there is no need to auto-create the live user
account, which is only supposed to happen in cases where the user
creation page is skipped.

https://phabricator.endlessm.com/T28041