### PR TITLE
Fix "Password hint" translation to pt_BR

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -539,7 +539,7 @@ msgstr "_Confirmar"
 
 #: gnome-initial-setup/pages/password/gis-password-page.ui:203
 msgid "Password _reminder"
-msgstr "Lembrete_de_senha"
+msgstr "_Lembrete de senha"
 
 #: gnome-initial-setup/pages/password/gis-password-page.ui:218
 msgid "Password reminder will be shown in case you forget your password."


### PR DESCRIPTION
Also needs to be cherry-picked to 3.7 which has the same issue.

https://phabricator.endlessm.com/T29000