### PR TITLE
network: react to devices being connected

### DIFF
--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -56,6 +56,9 @@ struct _GisNetworkPagePrivate {
   GtkSizeGroup *icons;
 
   guint refresh_timeout_id;
+
+  /* TRUE if the page has ever been shown to the user. */
+  gboolean ever_shown;
 };
 typedef struct _GisNetworkPagePrivate GisNetworkPagePrivate;
 
@@ -604,11 +607,31 @@ static void
 sync_complete (GisNetworkPage *page)
 {
   GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
+  gboolean has_device;
   gboolean activated;
+  gboolean visible;
 
-  activated = (nm_device_get_state (priv->nm_device) == NM_DEVICE_STATE_ACTIVATED);
+  has_device = priv->nm_device != NULL;
+  activated = priv->nm_device != NULL
+    && nm_device_get_state (priv->nm_device) == NM_DEVICE_STATE_ACTIVATED;
+
+  if (priv->ever_shown) {
+    visible = TRUE;
+  } else if (!has_device) {
+    g_debug ("No network device found, hiding network page");
+    visible = FALSE;
+  } else if (activated) {
+    g_debug ("Activated network device found, hiding network page");
+    visible = FALSE;
+  } else {
+    visible = TRUE;
+  }
+
   gis_page_set_complete (GIS_PAGE (page), activated);
-  schedule_refresh_wireless_list (page);
+  gtk_widget_set_visible (GTK_WIDGET (page), visible);
+
+  if (has_device)
+    schedule_refresh_wireless_list (page);
 }
 
 static void
@@ -626,7 +649,8 @@ find_best_device (GisNetworkPage *page)
 
   /* FIXME: deal with multiple devices and devices being removed */
   if (priv->nm_device != NULL) {
-    g_debug ("Already displaying %s", nm_device_get_description (priv->nm_device));
+    g_debug ("Already showing network device %s",
+             nm_device_get_description (priv->nm_device));
     return;
   }
 
@@ -641,18 +665,91 @@ find_best_device (GisNetworkPage *page)
     if (nm_device_get_device_type (device) == NM_DEVICE_TYPE_WIFI) {
       /* FIXME deal with multiple, dynamic devices */
       priv->nm_device = g_object_ref (device);
-      g_debug ("Displaying %s", nm_device_get_description (priv->nm_device));
+      g_debug ("Showing network device %s",
+               nm_device_get_description (priv->nm_device));
 
       g_signal_connect (priv->nm_device, "notify::state",
                         G_CALLBACK (device_state_changed), page);
       g_signal_connect (priv->nm_client, "notify::active-connections",
                         G_CALLBACK (active_connections_changed), page);
 
-      sync_complete (page);
-
       break;
     }
   }
+
+  sync_complete (page);
+}
+static void
+device_notify_managed (NMDevice   *device,
+                       GParamSpec *param,
+                       void       *user_data)
+{
+  GisNetworkPage *page = GIS_NETWORK_PAGE (user_data);
+
+  find_best_device (page);
+}
+
+static void
+client_device_added (NMClient *client,
+                     NMDevice *device,
+                     void     *user_data)
+{
+  GisNetworkPage *page = GIS_NETWORK_PAGE (user_data);
+
+  g_signal_connect_object (device,
+                           "notify::managed",
+                           G_CALLBACK (device_notify_managed),
+                           G_OBJECT (page),
+                           0);
+
+  find_best_device (page);
+}
+
+static void
+client_device_removed (NMClient *client,
+                       NMDevice *device,
+                       void     *user_data)
+{
+  GisNetworkPage *page = GIS_NETWORK_PAGE (user_data);
+
+  /* TODO: reset page if priv->nm_device == device */
+  g_signal_handlers_disconnect_by_func (device, device_notify_managed, page);
+
+  find_best_device (page);
+}
+
+static void
+monitor_network_devices (GisNetworkPage *page)
+{
+  GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
+  const GPtrArray *devices;
+  guint i;
+
+  g_assert (priv->nm_client != NULL);
+  devices = nm_client_get_devices (priv->nm_client);
+  g_return_if_fail (devices != NULL);
+  for (i = 0; devices != NULL && i < devices->len; i++) {
+    NMDevice *device = g_ptr_array_index (devices, i);
+
+    g_signal_connect_object (device,
+                             "notify::managed",
+                             G_CALLBACK (device_notify_managed),
+                             G_OBJECT (page),
+                             0);
+  }
+
+  g_signal_connect_object (priv->nm_client,
+                           "device-added",
+                           G_CALLBACK (client_device_added),
+                           G_OBJECT (page),
+                           0);
+  g_signal_connect_object (priv->nm_client,
+                           "device-removed",
+                           G_CALLBACK (client_device_removed),
+                           G_OBJECT (page),
+                           0);
+
+  find_best_device (page);
 }
 
 static void
@@ -660,13 +757,13 @@ gis_network_page_constructed (GObject *object)
 {
   GisNetworkPage *page = GIS_NETWORK_PAGE (object);
   GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
-  gboolean visible = FALSE;
   GError *error = NULL;
 
   G_OBJECT_CLASS (gis_network_page_parent_class)->constructed (object);
 
   gis_page_set_skippable (GIS_PAGE (page), TRUE);
 
+  priv->ever_shown = g_getenv ("GIS_ALWAYS_SHOW_NETWORK_PAGE") != NULL;
   priv->icons = gtk_size_group_new (GTK_SIZE_GROUP_HORIZONTAL);
 
   gtk_list_box_set_selection_mode (GTK_LIST_BOX (priv->network_list), GTK_SELECTION_NONE);
@@ -680,28 +777,14 @@ gis_network_page_constructed (GObject *object)
     g_warning ("Can't create NetworkManager client, hiding network page: %s",
                error->message);
     g_error_free (error);
-    goto out;
+    sync_complete (page);
+    return;
   }
 
   g_object_bind_property (priv->nm_client, "wireless-enabled",
                           priv->turn_on_switch, "active",
                           G_BINDING_BIDIRECTIONAL | G_BINDING_SYNC_CREATE);
-
-  find_best_device (page);
-
-  if (g_getenv ("GIS_ALWAYS_SHOW_NETWORK_PAGE") != NULL) {
-    /* Allow to always show the network page, for debugging purposes */
-    visible = TRUE;
-  } else if (priv->nm_device == NULL) {
-    g_debug ("No network device found, hiding network page");
-  } else if (nm_device_get_state (priv->nm_device) == NM_DEVICE_STATE_ACTIVATED) {
-    g_debug ("Activated network device found, hiding network page");
-  } else {
-    visible = TRUE;
-  }
-
-out:
-  gtk_widget_set_visible (GTK_WIDGET (page), visible);
+  monitor_network_devices (page);
 }
 
 static void
@@ -726,6 +809,14 @@ gis_network_page_locale_changed (GisPage *page)
 }
 
 static void
+gis_network_page_shown (GisPage *page)
+{
+  GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (GIS_NETWORK_PAGE (page));
+
+  priv->ever_shown = TRUE;
+}
+
+static void
 gis_network_page_class_init (GisNetworkPageClass *klass)
 {
   GisPageClass *page_class = GIS_PAGE_CLASS (klass);
@@ -742,6 +833,7 @@ gis_network_page_class_init (GisNetworkPageClass *klass)
 
   page_class->page_id = PAGE_ID;
   page_class->locale_changed = gis_network_page_locale_changed;
+  page_class->shown = gis_network_page_shown;
   object_class->constructed = gis_network_page_constructed;
   object_class->dispose = gis_network_page_dispose;
 }

--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -467,16 +467,15 @@ connection_activate_cb (GObject *object,
                         gpointer user_data)
 {
   NMClient *client = NM_CLIENT (object);
-  NMActiveConnection *connection;
-  GError *error = NULL;
+  NMActiveConnection *connection = NULL;
+  g_autoptr(GError) error = NULL;
 
   connection = nm_client_activate_connection_finish (client, result, &error);
-  if (connection) {
-    g_object_unref (connection);
+  if (connection != NULL) {
+    g_clear_object (&connection);
   } else {
     /* failed to activate */
     g_warning ("Failed to activate a connection: %s", error->message);
-    g_error_free (error);
   }
 }
 
@@ -486,16 +485,15 @@ connection_add_activate_cb (GObject *object,
                             gpointer user_data)
 {
   NMClient *client = NM_CLIENT (object);
-  NMActiveConnection *connection;
-  GError *error = NULL;
+  NMActiveConnection *connection = NULL;
+  g_autoptr(GError) error = NULL;
 
   connection = nm_client_add_and_activate_connection_finish (client, result, &error);
-  if (connection) {
-    g_object_unref (connection);
+  if (connection != NULL) {
+    g_clear_object (&connection);
   } else {
     /* failed to activate */
     g_warning ("Failed to add and activate a connection: %s", error->message);
-    g_error_free (error);
   }
 }
 
@@ -757,7 +755,7 @@ gis_network_page_constructed (GObject *object)
 {
   GisNetworkPage *page = GIS_NETWORK_PAGE (object);
   GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
-  GError *error = NULL;
+  g_autoptr(GError) error = NULL;
 
   G_OBJECT_CLASS (gis_network_page_parent_class)->constructed (object);
 
@@ -776,7 +774,6 @@ gis_network_page_constructed (GObject *object)
   if (!priv->nm_client) {
     g_warning ("Can't create NetworkManager client, hiding network page: %s",
                error->message);
-    g_error_free (error);
     sync_complete (page);
     return;
   }

--- a/gnome-initial-setup/pages/network/gis-network-page.c
+++ b/gnome-initial-setup/pages/network/gis-network-page.c
@@ -56,16 +56,6 @@ struct _GisNetworkPagePrivate {
   GtkSizeGroup *icons;
 
   guint refresh_timeout_id;
-
-  /* If nm_device is in state ACTIVATED, but nm_client's connectivity is not
-   * yet FULL, the event source ID for a timeout. 0 otherwise, or after the
-   * timeout fires.
-   */
-  guint wait_connected_timeout_id;
-  /* If TRUE, we waited a few seconds after the device moved to state ACTIVATED
-   * but connectivity did not become FULL.
-   */
-  gboolean wait_connected_timed_out;
 };
 typedef struct _GisNetworkPagePrivate GisNetworkPagePrivate;
 
@@ -610,79 +600,19 @@ active_connections_changed (NMClient *client, GParamSpec *pspec, GisNetworkPage 
   }
 }
 
-static gboolean wait_connected_timeout_cb (gpointer);
-
 static void
 sync_complete (GisNetworkPage *page)
 {
   GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
-  NMDeviceState device_state;
-  NMConnectivityState connectivity;
-  gboolean activated, connectivity_check_complete;
+  gboolean activated;
 
-  device_state = nm_device_get_state (priv->nm_device);
-  connectivity = nm_client_get_connectivity (priv->nm_client);
-  activated = device_state == NM_DEVICE_STATE_ACTIVATED;
-  connectivity_check_complete = connectivity != NM_CONNECTIVITY_NONE;
-  g_debug ("device_state: %u, connectivity: %u, wait_connected_timed_out: %u",
-           device_state, connectivity, priv->wait_connected_timed_out);
-
-  /* Only consider the page complete when a network interface is activated,
-   * and the connectivity check is completed or has timed out. This improves the
-   * chance that GeoClue will have a chance to detect our location before we
-   * reach the timezone page.
-   */
-  gis_page_set_complete (GIS_PAGE (page),
-                         activated && (connectivity_check_complete ||
-                                       priv->wait_connected_timed_out));
-
-  if (activated && /* link is up */
-      !connectivity_check_complete && /* connectivity check is pending */
-      !priv->wait_connected_timed_out && /* we haven't already waited */
-      priv->wait_connected_timeout_id == 0 /* we aren't already waiting */
-      ) {
-    static const guint wait_for_connectivity_sec = 3;
-    g_debug ("Device activated; waiting %u seconds for connectivity check",
-             wait_for_connectivity_sec);
-    priv->wait_connected_timeout_id =
-        g_timeout_add_seconds (wait_for_connectivity_sec,
-                               wait_connected_timeout_cb,
-                               page);
-  } else if (!activated || connectivity_check_complete) {
-    g_debug ("%s; clearing connectivity check timeout & flag",
-             activated ? "Connectivity check complete"
-                       : "Device deactivated");
-    g_clear_handle_id (&priv->wait_connected_timeout_id, g_source_remove);
-    priv->wait_connected_timed_out = FALSE;
-  }
-
+  activated = (nm_device_get_state (priv->nm_device) == NM_DEVICE_STATE_ACTIVATED);
+  gis_page_set_complete (GIS_PAGE (page), activated);
   schedule_refresh_wireless_list (page);
-}
-
-static gboolean
-wait_connected_timeout_cb (gpointer data)
-{
-  GisNetworkPage *page = GIS_NETWORK_PAGE (data);
-  GisNetworkPagePrivate *priv = gis_network_page_get_instance_private (page);
-
-  g_debug ("Timed out waiting for connectivity check");
-
-  priv->wait_connected_timeout_id = 0;
-  priv->wait_connected_timed_out = TRUE;
-
-  sync_complete (page);
-
-  return G_SOURCE_REMOVE;
 }
 
 static void
 device_state_changed (GObject *object, GParamSpec *param, GisNetworkPage *page)
-{
-  sync_complete (page);
-}
-
-static void
-connectivity_changed (GObject *object, GParamSpec *param, GisNetworkPage *page)
 {
   sync_complete (page);
 }
@@ -749,8 +679,6 @@ gis_network_page_constructed (GObject *object)
                     G_CALLBACK (device_state_changed), page);
   g_signal_connect (priv->nm_client, "notify::active-connections",
                     G_CALLBACK (active_connections_changed), page);
-  g_signal_connect (priv->nm_client, "notify::connectivity",
-                    G_CALLBACK (connectivity_changed), page);
 
   gtk_list_box_set_selection_mode (GTK_LIST_BOX (priv->network_list), GTK_SELECTION_NONE);
   gtk_list_box_set_header_func (GTK_LIST_BOX (priv->network_list), update_header_func, NULL, NULL);
@@ -777,7 +705,6 @@ gis_network_page_dispose (GObject *object)
   g_clear_object (&priv->icons);
 
   cancel_periodic_refresh (page);
-  g_clear_handle_id (&priv->wait_connected_timeout_id, g_source_remove);
 
   G_OBJECT_CLASS (gis_network_page_parent_class)->dispose (object);
 }


### PR DESCRIPTION
A clean backport of
https://gitlab.gnome.org/GNOME/gnome-initial-setup/merge_requests/69,
complicated only by my own downstream conflicting change. This branch
reverts that change, backports !69, and then applies a refreshed version
of that patch which I have posted to
https://gitlab.gnome.org/GNOME/gnome-initial-setup/merge_requests/74.

https://phabricator.endlessm.com/T27527