### PR TITLE
fixup! account-local: add toggle for passwordless accounts

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page-local.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.ui
@@ -141,7 +141,6 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="password_toggle">
-                <property name="halign">end</property>
                 <property name="label" translatable="yes">Set a password</property>
               </object>
               <packing>


### PR DESCRIPTION
Fix horizontal alignment of "Set a password" checkbox. This should be
squashed on the next rebase.

https://phabricator.endlessm.com/T29552