### PR TITLE
eos: Report metrics from parental controls page

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -75,7 +75,7 @@ conf.set('HAVE_IBUS', ibus_dep.found())
 
 # Needed for the parental controls pages
 libmalcontent_dep = dependency ('malcontent-0',
-                                version: '>= 0.6.0',
+                                version: '>= 0.7.0',
                                 required: get_option('parental_controls'))
 libmalcontent_ui_dep = dependency ('malcontent-ui-0',
                                    version: '>= 0.6.0',


### PR DESCRIPTION
If the user chooses to enable parental controls when setting up the
computer, send a metrics event which contains the initial parental
controls settings. Don’t send an event if parental controls are not
enabled.

This will give us an idea of the more and less popular parental controls
features. If they are compared against parental controls settings set or
changed after initial setup, this metric will also give us an idea of
how people change their parental controls (presumably tweaking them
since they set them incorrectly in the first place).

This commit should not be upstreamed.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28742