### PR TITLE
account: Make admin account usable in case of errors

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -603,6 +603,10 @@ local_create_user (GisAccountPageLocal *local,
       return;
     }
 
+    /* Make the admin account usable in case g-i-s crashes. If all goes
+     * according to plan a password will be set on it in gis-password-page.c */
+    act_user_set_password_mode (parent_user, ACT_USER_PASSWORD_MODE_SET_AT_LOGIN);
+
     /* Mark it as the parent user account.
      * FIXME: This should be async. */
     connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &local_error);


### PR DESCRIPTION
In gis-account-page-local.c, if parental controls are enabled we create
an administrator account which will be used by the parent, and we create
it before the child's account so that the system will not be left
without any admin accounts in case g-i-s crashes or otherwise doesn't
finish. However this isn't especially helpful since the account is not
set to be passwordless (ACT_USER_PASSWORD_MODE_NONE) so cannot easily be
used if the user doesn't make it to the page where they are asked to set
a password on it. So, set the admin account to
ACT_USER_PASSWORD_MODE_SET_AT_LOGIN temporarily. When a password is set
on the account by the password page, accountsservice will set it to
ACT_USER_PASSWORD_MODE_REGULAR.

This seems like a slightly better policy than making the account
passwordless, since we shouldn't encourage passwordless admin accounts.

https://phabricator.endlessm.com/T28787