### PR TITLE
Fix crashes when saving parental controls settings

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -533,8 +533,12 @@ gis_driver_get_user_permissions (GisDriver    *driver,
                                  const gchar **password)
 {
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
-  *user = priv->user_account;
-  *password = priv->user_password;
+
+  if (user != NULL)
+    *user = priv->user_account;
+
+  if (password != NULL)
+    *password = priv->user_password;
 }
 
 /**

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -524,6 +524,7 @@ gis_driver_set_user_permissions (GisDriver   *driver,
 {
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
   g_set_object (&priv->user_account, user);
+  g_free (priv->user_password);
   priv->user_password = g_strdup (password);
 }
 
@@ -560,7 +561,7 @@ gis_driver_set_parent_permissions (GisDriver   *driver,
   GisDriverPrivate *priv = gis_driver_get_instance_private (driver);
 
   g_set_object (&priv->parent_account, parent);
-  g_assert (priv->parent_password == NULL);
+  g_free (priv->parent_password);
   priv->parent_password = g_strdup (password);
 }
 


### PR DESCRIPTION
These are cherry picks from this upstream MR: https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/merge_requests/80

https://phabricator.endlessm.com/T28787