### PR TITLE
fixup! password: Add eye icons to toggle password visibility

### DIFF
--- a/gnome-initial-setup/pages/password/gis-password-page.c
+++ b/gnome-initial-setup/pages/password/gis-password-page.c
@@ -327,11 +327,15 @@ on_entry_icon_press (GtkEntry            *entry,
   if (icon_pos != GTK_ENTRY_ICON_SECONDARY)
     return;
 
+  /* We show the eye icon with a slash through it when the password is not
+   * visible, which is consistent with how gnome-shell works in
+   * StPasswordEntry.
+   */
   if (gtk_entry_get_visibility (entry))
     {
       gtk_entry_set_visibility (entry, FALSE);
       gtk_entry_set_icon_from_icon_name (entry, GTK_ENTRY_ICON_SECONDARY,
-                                         "eye-open-negative-filled-symbolic");
+                                         "eye-not-looking-symbolic");
       gtk_entry_set_icon_tooltip_text (entry, GTK_ENTRY_ICON_SECONDARY,
                                        _("Show password"));
     }
@@ -339,7 +343,7 @@ on_entry_icon_press (GtkEntry            *entry,
     {
       gtk_entry_set_visibility (entry, TRUE);
       gtk_entry_set_icon_from_icon_name (entry, GTK_ENTRY_ICON_SECONDARY,
-                                         "eye-not-looking-symbolic");
+                                         "eye-open-negative-filled-symbolic");
       gtk_entry_set_icon_tooltip_text (entry, GTK_ENTRY_ICON_SECONDARY,
                                        _("Hide password"));
     }

--- a/gnome-initial-setup/pages/password/gis-password-page.ui
+++ b/gnome-initial-setup/pages/password/gis-password-page.ui
@@ -49,7 +49,7 @@
                 <property name="visibility">False</property>
                 <property name="invisible_char">●</property>
                 <property name="invisible_char_set">True</property>
-                <property name="secondary_icon_name">eye-open-negative-filled-symbolic</property>
+                <property name="secondary_icon_name">eye-not-looking-symbolic</property>
                 <property name="secondary_icon_tooltip_text">Show password</property>
                 <property name="caps_lock_warning">False</property>
               </object>
@@ -84,7 +84,7 @@
                 <property name="visibility">False</property>
                 <property name="invisible_char">●</property>
                 <property name="invisible_char_set">True</property>
-                <property name="secondary_icon_name">eye-open-negative-filled-symbolic</property>
+                <property name="secondary_icon_name">eye-not-looking-symbolic</property>
                 <property name="secondary_icon_tooltip_text">Show password</property>
                 <property name="caps_lock_warning">False</property>
               </object>


### PR DESCRIPTION
Make the "show password" icon match the one in GNOME Shell, rather than
being reversed.

https://phabricator.endlessm.com/T29262