### PR TITLE
fixup! account-local: add toggle for passwordless accounts

### DIFF
--- a/gnome-initial-setup/pages/password/gis-password-page.c
+++ b/gnome-initial-setup/pages/password/gis-password-page.c
@@ -394,7 +394,7 @@ username_or_passwordless_changed (GisPasswordPage *page)
   priv->username = gis_driver_get_username (GIS_PAGE (page)->driver);
   gboolean passwordless = gis_driver_get_passwordless (GIS_PAGE (page)->driver);
 
-  if (priv->username && !passwordless)
+  if (priv->parent_mode || (priv->username && !passwordless))
     gtk_widget_show (GTK_WIDGET (page));
   else
     gtk_widget_hide (GTK_WIDGET (page));


### PR DESCRIPTION
This fixes the parent password page so that it shows when parental
controls are enabled, regardless of whether the passwordless toggle was
checked for the main user. The parent password page should be shown if
(and only if) parental controls are enabled.

https://phabricator.endlessm.com/T28739