### PR TITLE
account: Use custom setting to override faces

### DIFF
--- a/gnome-initial-setup/pages/account/um-photo-dialog.c
+++ b/gnome-initial-setup/pages/account/um-photo-dialog.c
@@ -217,72 +217,72 @@ create_face_widget (gpointer item,
         return image;
 }
 
-static GSList *
+static GStrv
 get_settings_facesdirs (void)
 {
-        g_autoptr(GSettings) settings = NULL;
         g_autoptr(GSettingsSchema) schema = NULL;
-
-        GSList *facesdirs = NULL;
-        char **settings_dirs;
-        int i;
-
+        g_autoptr(GSettings) settings = NULL;
+        g_auto(GStrv) settings_dirs = NULL;
+        g_autoptr(GPtrArray) facesdirs = NULL;
         GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
 
-        if (!source)
-                return facesdirs;
+        facesdirs = g_ptr_array_new ();
 
-        schema = g_settings_schema_source_lookup (source,
-                                                  "org.gnome.desktop.interface",
-                                                  FALSE);
-
-        if (!schema || !g_settings_schema_has_key (schema, "facesdirs"))
-                return facesdirs;
-
-        settings = g_settings_new ("org.gnome.desktop.interface");
-
-        settings_dirs = g_settings_get_strv (settings, "facesdirs");
-        if (settings_dirs != NULL) {
-                for (i = 0; settings_dirs[i] != NULL; i++) {
-                        char *path = settings_dirs[i];
-                        if (path != NULL && g_strcmp0 (path, "") != 0)
-                                facesdirs = g_slist_prepend (facesdirs, g_strdup (path));
-                }
-                g_strfreev (settings_dirs);
+        if (source) {
+                schema = g_settings_schema_source_lookup (source,
+                                                          "org.gnome.desktop.interface",
+                                                          FALSE);
         }
 
-        return g_slist_reverse (facesdirs);
+        if (schema) {
+                settings = g_settings_new_with_path ("org.gnome.desktop.interface",
+                                                     "/org/gnome/desktop/interface/");
+                settings_dirs = g_settings_get_strv (settings, "facesdirs");
+
+                if (settings_dirs != NULL) {
+                        int i;
+                        for (i = 0; settings_dirs[i] != NULL; i++) {
+                                char *path = settings_dirs[i];
+                                if (path != NULL && g_strcmp0 (path, "") != 0)
+                                        g_ptr_array_add (facesdirs, g_strdup (path));
+                        }
+                }
+        }
+
+        return (GStrv) g_steal_pointer (&facesdirs->pdata);
 }
 
-static GSList *
+static GStrv
 get_system_facesdirs (void)
 {
-        GSList *facesdirs = NULL;
+        g_autoptr(GPtrArray) facesdirs = NULL;
         const char * const * data_dirs;
         int i;
+
+        facesdirs = g_ptr_array_new ();
 
         data_dirs = g_get_system_data_dirs ();
         for (i = 0; data_dirs[i] != NULL; i++) {
                 char *path = g_build_filename (data_dirs[i], "pixmaps", "faces", NULL);
-                facesdirs = g_slist_prepend (facesdirs, path);
+                g_ptr_array_add (facesdirs, path);
         }
 
-        return g_slist_reverse (facesdirs);
+        return (GStrv) g_steal_pointer (&facesdirs->pdata);
 }
 
 static gboolean
-add_faces_from_dirs (GListStore *faces, GSList *facesdirs, gboolean add_all)
+add_faces_from_dirs (GListStore *faces, GStrv facesdirs, gboolean add_all)
 {
-        GSList *facesdir_it;
         gboolean added_faces = FALSE;
         const gchar *target;
+        int i;
         GFileType type;
 
-        for (facesdir_it = facesdirs; facesdir_it; facesdir_it = facesdir_it->next) {
+        for (i = 0; facesdirs[i] != NULL; i++) {
                 g_autoptr(GFileEnumerator) enumerator = NULL;
                 g_autoptr(GFile) dir = NULL;
+                const char *path = facesdirs[i];
                 gpointer infoptr;
-                const char *path = facesdir_it->data;
 
                 dir = g_file_new_for_path (path);
                 enumerator = g_file_enumerate_children (dir,
@@ -292,6 +292,7 @@ add_faces_from_dirs (GListStore *faces, GSList *facesdirs, gboolean add_all)
                                                         G_FILE_ATTRIBUTE_STANDARD_SYMLINK_TARGET,
                                                         G_FILE_QUERY_INFO_NONE,
                                                         NULL, NULL);
+
                 if (enumerator == NULL)
                         continue;
 
@@ -317,14 +318,13 @@ add_faces_from_dirs (GListStore *faces, GSList *facesdirs, gboolean add_all)
                 if (added_faces && !add_all)
                         break;
         }
-
         return added_faces;
 }
 
 static void
 setup_photo_popup (UmPhotoDialog *um)
 {
-        GSList *facesdirs;
+        g_auto(GStrv) facesdirs;
         gboolean added_faces = FALSE;
 
         um->faces = g_list_store_new (G_TYPE_FILE);
@@ -349,12 +349,10 @@ setup_photo_popup (UmPhotoDialog *um)
 
         facesdirs = get_settings_facesdirs ();
         added_faces = add_faces_from_dirs (um->faces, facesdirs, TRUE);
-        g_slist_free_full (facesdirs, g_free);
 
         if (!added_faces) {
                 facesdirs = get_system_facesdirs ();
                 add_faces_from_dirs (um->faces, facesdirs, FALSE);
-                g_slist_free_full (facesdirs, g_free);
         }
 
 #ifdef HAVE_CHEESE


### PR DESCRIPTION
This patch uses the org.gnome.desktop.interface.facesdirs
configuration to override the default faces dir.

https://phabricator.endlessm.com/T29718