### PR TITLE
T27791 Fix use of uninitialised memory with input chooser

### DIFF
--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -921,7 +921,12 @@ cc_input_chooser_get_layout (CcInputChooser *chooser,
 {
         CcInputChooserPrivate *priv = cc_input_chooser_get_instance_private (chooser);
 
-	get_layout (chooser, priv->type, priv->id, layout, variant);
+        if (!get_layout (chooser, priv->type, priv->id, layout, variant)) {
+                if (layout != NULL)
+                        *layout = NULL;
+                if (variant != NULL)
+                        *variant = NULL;
+        }
 }
 
 void

--- a/gnome-initial-setup/pages/keyboard/gis-keyboard-page.c
+++ b/gnome-initial-setup/pages/keyboard/gis-keyboard-page.c
@@ -376,14 +376,14 @@ preselect_input_source (GisKeyboardPage *self)
          * add both system keyboard layout and the ibus input method. */
         language = cc_common_language_get_current_language ();
 
-        if (!priv->system_sources ||
-            (gnome_get_input_source_from_locale (language, &type, &id) && g_strcmp0 (type, "xkb") != 0)) {
-                cc_input_chooser_set_input (CC_INPUT_CHOOSER (priv->input_chooser),
-                                            id, type);
-        } else {
+        if (priv->system_sources) {
                 cc_input_chooser_set_input (CC_INPUT_CHOOSER (priv->input_chooser),
                                             (const gchar *) priv->system_sources->data,
                                             "xkb");
+        } else if (gnome_get_input_source_from_locale (language, &type, &id) &&
+                   g_strcmp0 (type, "xkb") != 0) {
+                cc_input_chooser_set_input (CC_INPUT_CHOOSER (priv->input_chooser),
+                                            id, type);
         }
 
         g_free (language);


### PR DESCRIPTION
Trivial cherry-pick of the two commits from https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/merge_requests/82.

https://phabricator.endlessm.com/T27791