### PR TITLE
Use panel extension on session

### DIFF
--- a/data/initial-setup.json
+++ b/data/initial-setup.json
@@ -1,6 +1,8 @@
 {
     "hasWindows": true,
     "components": ["networkAgent"],
+    "allowExtensions": true,
+    "enabledExtensions": ["eos-panel@endlessm.com"],
     "panel": { "left": [],
                "center": [],
                "right": ["a11y", "keyboard", "aggregateMenu"]

--- a/data/initial-setup.json
+++ b/data/initial-setup.json
@@ -3,6 +3,6 @@
     "components": ["networkAgent"],
     "panel": { "left": [],
                "center": [],
-               "right": ["a11y", "keyboard", "aggregateMenu", "powerMenu"]
+               "right": ["a11y", "keyboard", "aggregateMenu"]
     }
 }


### PR DESCRIPTION
The panel customizations from Endless are now done as part of panel extension so let's enable it here.
    
Note we don't change the default panel layout defined for the session, but that is because the panel extension will ignore it (and define its own layout) and if the panel extension fails to load we fallback to the layout set here instead of breaking the session.
 
See also https://github.com/endlessm/eos-panel-extension/pull/3 (**not** a hard dep).

https://phabricator.endlessm.com/T30445
