### PR TITLE
debian: Change malcontent recommends to malcontent-data

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+gnome-initial-setup (3.37.92-1endless1) eos; urgency=medium
+
+  * Change malcontent recommends to malcontent-data to account for differences
+    in package naming between Endless and Debian; this can be dropped when
+    T30746 is fixed (see also T30173)
+
+ -- Philip Withnall <withnall@endlessm.com>  Thu, 10 Sep 2020 13:38:00 +0100
+
 gnome-initial-setup (3.37.92-1endless0) eos; urgency=medium
 
   * Endless 3.37.92 release

--- a/debian/control
+++ b/debian/control
@@ -60,7 +60,7 @@ Recommends: accountsservice,
             geoclue-2.0 (>= 2.3.1),
             gnome-getting-started-docs,
             gnome-keyring,
-            malcontent [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+            malcontent-data [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
 Suggests: gdm3,
 Description: Initial GNOME system setup helper
  After acquiring or installing a new system there are a few essential things

--- a/debian/control.in
+++ b/debian/control.in
@@ -56,7 +56,7 @@ Recommends: accountsservice,
             geoclue-2.0 (>= 2.3.1),
             gnome-getting-started-docs,
             gnome-keyring,
-            malcontent [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+            malcontent-data [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
 Suggests: gdm3,
 Description: Initial GNOME system setup helper
  After acquiring or installing a new system there are a few essential things


### PR DESCRIPTION
This accounts for differences in package naming between Endless and
Debian; this can be dropped when T30746 is fixed (see also T30173).

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T30173