### PR TITLE
T30173 Misc use-after-free fixes

### DIFF
--- a/gnome-initial-setup/pages/account/um-realm-manager.c
+++ b/gnome-initial-setup/pages/account/um-realm-manager.c
@@ -158,7 +158,7 @@ on_provider_new (GObject *source,
         manager->provider = provider;
         g_dbus_proxy_set_default_timeout (G_DBUS_PROXY (manager->provider), -1);
         g_debug ("Created realm manager");
-        g_task_return_pointer (task, manager, g_object_unref);
+        g_task_return_pointer (task, g_object_ref (manager), g_object_unref);
 }
 
 static void

--- a/gnome-initial-setup/pages/language/gis-welcome-widget.c
+++ b/gnome-initial-setup/pages/language/gis-welcome-widget.c
@@ -31,7 +31,7 @@
 struct _GisWelcomeWidgetPrivate
 {
   GtkWidget *stack;
-  GHashTable *translation_widgets;
+  GHashTable *translation_widgets;  /* (element-type owned utf8 unowned GtkWidget) (owned) */
 
   guint timeout_id;
 };
@@ -181,7 +181,7 @@ fill_stack (GisWelcomeWidget *widget)
         g_hash_table_insert (added_translations, (gpointer) text, label);
       }
 
-      g_hash_table_insert (priv->translation_widgets, locale_id, label);
+      g_hash_table_insert (priv->translation_widgets, g_strdup (locale_id), label);
     }
 }
 
@@ -223,7 +223,7 @@ gis_welcome_widget_init (GisWelcomeWidget *widget)
 {
   GisWelcomeWidgetPrivate *priv = gis_welcome_widget_get_instance_private (widget);
 
-  priv->translation_widgets = g_hash_table_new (g_str_hash, g_str_equal);
+  priv->translation_widgets = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   gtk_widget_init_template (GTK_WIDGET (widget));
 }

--- a/gnome-initial-setup/pages/language/gis-welcome-widget.c
+++ b/gnome-initial-setup/pages/language/gis-welcome-widget.c
@@ -109,12 +109,12 @@ gis_welcome_widget_unmap (GtkWidget *widget)
   gis_welcome_widget_stop (GIS_WELCOME_WIDGET (widget));
 }
 
-static char *
+static const char *
 welcome (const char *locale_id)
 {
   locale_t locale;
   locale_t old_locale;
-  char *welcome;
+  const char *welcome;
 
   locale = newlocale (LC_MESSAGES_MASK, locale_id, (locale_t) 0);
   if (locale == (locale_t) 0)
@@ -165,8 +165,8 @@ fill_stack (GisWelcomeWidget *widget)
   g_hash_table_iter_init (&iter, initial);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
-      char *locale_id = key;
-      char *text;
+      const char *locale_id = key;
+      const char *text;
       GtkWidget *label;
 
       if (!cc_common_language_has_font (locale_id))
@@ -178,7 +178,7 @@ fill_stack (GisWelcomeWidget *widget)
         label = big_label (text);
         gtk_container_add (GTK_CONTAINER (priv->stack), label);
         gtk_widget_show (label);
-        g_hash_table_insert (added_translations, text, label);
+        g_hash_table_insert (added_translations, (gpointer) text, label);
       }
 
       g_hash_table_insert (priv->translation_widgets, locale_id, label);

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.c
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.c
@@ -181,13 +181,12 @@ on_geoclue_simple_ready (GObject      *source_object,
 {
   GisTimezonePage *page = user_data;
   GisTimezonePagePrivate *priv = gis_timezone_page_get_instance_private (page);
-  GError *error = NULL;
+  g_autoptr(GError) local_error = NULL;
 
-  priv->geoclue_simple = gclue_simple_new_finish (res, &error);
-  if (error != NULL)
+  priv->geoclue_simple = gclue_simple_new_finish (res, &local_error);
+  if (local_error != NULL)
     {
-      g_critical ("Failed to connect to GeoClue2 service: %s", error->message);
-      g_error_free (error);
+      g_critical ("Failed to connect to GeoClue2 service: %s", local_error->message);
       return;
     }
 

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.c
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.c
@@ -186,7 +186,8 @@ on_geoclue_simple_ready (GObject      *source_object,
   priv->geoclue_simple = gclue_simple_new_finish (res, &local_error);
   if (local_error != NULL)
     {
-      g_critical ("Failed to connect to GeoClue2 service: %s", local_error->message);
+      if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+        g_critical ("Failed to connect to GeoClue2 service: %s", local_error->message);
       return;
     }
 

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.c
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.c
@@ -57,6 +57,11 @@
 #define CLOCK_SCHEMA "org.gnome.desktop.interface"
 #define CLOCK_FORMAT_KEY "clock-format"
 
+/* FIXME: Drop this when we depend on a version of GeoClue which has
+ * https://gitlab.freedesktop.org/geoclue/geoclue/-/merge_requests/73 */
+typedef GClueSimple MyGClueSimple;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (MyGClueSimple, g_object_unref)
+
 static void stop_geolocation (GisTimezonePage *page);
 
 struct _GisTimezonePagePrivate
@@ -182,8 +187,12 @@ on_geoclue_simple_ready (GObject      *source_object,
   GisTimezonePage *page = user_data;
   GisTimezonePagePrivate *priv = gis_timezone_page_get_instance_private (page);
   g_autoptr(GError) local_error = NULL;
+  g_autoptr(MyGClueSimple) geoclue_simple = NULL;
 
-  priv->geoclue_simple = gclue_simple_new_finish (res, &local_error);
+  /* This function may be called in an idle callback once @page has been
+   * disposed, if going through cancellation. So don’t dereference @priv or
+   * @page until the error has been checked. */
+  geoclue_simple = gclue_simple_new_finish (res, &local_error);
   if (local_error != NULL)
     {
       if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
@@ -191,6 +200,7 @@ on_geoclue_simple_ready (GObject      *source_object,
       return;
     }
 
+  priv->geoclue_simple = g_steal_pointer (&geoclue_simple);
   priv->geoclue_client = gclue_simple_get_client (priv->geoclue_simple);
   gclue_client_set_distance_threshold (priv->geoclue_client,
                                        GEOCODE_LOCATION_ACCURACY_CITY);


### PR DESCRIPTION
These won’t fix T30173 but make debugging it a little less noisy.

All upstream in https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/merge_requests/103 except the `UmRealmManager` fixes which fix a bug introduced in our downstream commit “copypasta code: Use GTask in UmRealmManager”.