### PR TITLE
Revert "account: Check configuration to hide password switch if needed"

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -763,11 +763,3 @@ gis_account_page_local_shown (GisAccountPageLocal *local)
   GisAccountPageLocalPrivate *priv = gis_account_page_local_get_instance_private (local);
   gtk_widget_grab_focus (priv->fullname_entry);
 }
-
-void
-gis_account_page_local_show_password_toggle (GisAccountPageLocal *local,
-                                             gboolean show_password_toggle)
-{
-  GisAccountPageLocalPrivate *priv = gis_account_page_local_get_instance_private (local);
-  gtk_widget_set_visible (priv->password_toggle, show_password_toggle);
-}

--- a/gnome-initial-setup/pages/account/gis-account-page-local.h
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.h
@@ -54,8 +54,6 @@ gboolean gis_account_page_local_create_user (GisAccountPageLocal  *local,
                                              GisPage              *page,
                                              GError              **error);
 void gis_account_page_local_shown (GisAccountPageLocal *local);
-void gis_account_page_local_show_password_toggle (GisAccountPageLocal *local,
-                                                  gboolean show_password_toggle);
 
 G_END_DECLS
 

--- a/gnome-initial-setup/pages/account/gis-account-page.c
+++ b/gnome-initial-setup/pages/account/gis-account-page.c
@@ -32,9 +32,6 @@
 #include <glib/gi18n.h>
 #include <gio/gio.h>
 
-#define CONFIG_ACCOUNT_GROUP "page.account"
-#define CONFIG_ACCOUNT_SHOW_PASSWORD_SWITCH_KEY "show-password-switch"
-
 struct _GisAccountPagePrivate
 {
   GtkWidget *page_local;
@@ -89,22 +86,6 @@ on_validation_changed (gpointer        page_area,
   update_page_validation (page);
 }
 
-
-static void
-hide_password_toggle_if_needed (GisAccountPage *page)
-{
-  GisAccountPagePrivate *priv = gis_account_page_get_instance_private (page);
-  gboolean show_password_toggle;
-
-  /* check the conf file to see if the password toggle should be shown/hidden */
-  show_password_toggle = gis_driver_conf_get_boolean (GIS_PAGE (page)->driver,
-                                                      CONFIG_ACCOUNT_GROUP,
-                                                      CONFIG_ACCOUNT_SHOW_PASSWORD_SWITCH_KEY,
-                                                      TRUE);
-  gis_account_page_local_show_password_toggle (GIS_ACCOUNT_PAGE_LOCAL (priv->page_local),
-                                               show_password_toggle);
-}
-
 static void
 set_mode (GisAccountPage *page,
           UmAccountMode   mode)
@@ -122,7 +103,6 @@ set_mode (GisAccountPage *page,
     case UM_LOCAL:
       gtk_stack_set_visible_child (GTK_STACK (priv->stack), priv->page_local);
       gis_account_page_local_shown (GIS_ACCOUNT_PAGE_LOCAL (priv->page_local));
-      hide_password_toggle_if_needed (page);
       break;
     case UM_ENTERPRISE:
       gtk_stack_set_visible_child (GTK_STACK (priv->stack), priv->page_enterprise);


### PR DESCRIPTION
This reverts commit 2c7590a6f51c6c942c93a02fb8e26716efe42f36.

This was used only by Hack, and we are removing that configuration (https://github.com/endlessm/eos-image-builder/pull/899).

https://phabricator.endlessm.com/T29974