### PR TITLE
fixup! account-local: add toggle for passwordless accounts

### DIFF
--- a/gnome-initial-setup/pages/account/gis-account-page-local.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.ui
@@ -141,6 +141,7 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="password_toggle">
+                <property name="visible">True</property>
                 <property name="label" translatable="yes">Set a password</property>
               </object>
               <packing>


### PR DESCRIPTION
The `visible` property was missing from the original commit as it was
designed to be set dynamically — but the code (and need) to do that has
now been removed.

This should be squashed when we next rebase.

https://phabricator.endlessm.com/T31001