### PR TITLE
Revert "driver: Make height 768 the threshold for "small screens""

### DIFF
--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -835,7 +835,7 @@ monitor_is_small (GdkMonitor *monitor)
     return TRUE;
 
   gdk_monitor_get_geometry (monitor, &geom);
-  return geom.height < 768;
+  return geom.height < 800;
 }
 
 static void


### PR DESCRIPTION
This reverts commit 7eb144d7a3e2a8393e079e78318393a8091f12a3.

It was decided upstream
(https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/merge_requests/96)
that this patch actually makes things worse for those devices, as
without this patch small screen mode would be triggered on the devices
in question, which should make the g-i-s pages scrollable.

See https://phabricator.endlessm.com/T27792