### PR TITLE
Revert "debian: Change malcontent recommends to malcontent-data"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,14 +11,6 @@ gnome-initial-setup (3.38.0-1endless0) eos; urgency=medium
 
  -- Philip Withnall <pwithnall@endlessos.org>  Thu, 17 Sep 2020 17:00:00 +0100
 
-gnome-initial-setup (3.37.92-1endless1) eos; urgency=medium
-
-  * Change malcontent recommends to malcontent-data to account for differences
-    in package naming between Endless and Debian; this can be dropped when
-    T30746 is fixed (see also T30173)
-
- -- Philip Withnall <withnall@endlessm.com>  Thu, 10 Sep 2020 13:38:00 +0100
-
 gnome-initial-setup (3.37.92-1endless0) eos; urgency=medium
 
   * Endless 3.37.92 release

--- a/debian/control
+++ b/debian/control
@@ -60,7 +60,7 @@ Recommends: accountsservice,
             geoclue-2.0 (>= 2.3.1),
             gnome-getting-started-docs,
             gnome-keyring,
-            malcontent-data [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+            malcontent [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
 Suggests: gdm3,
 Description: Initial GNOME system setup helper
  After acquiring or installing a new system there are a few essential things

--- a/debian/control.in
+++ b/debian/control.in
@@ -56,7 +56,7 @@ Recommends: accountsservice,
             geoclue-2.0 (>= 2.3.1),
             gnome-getting-started-docs,
             gnome-keyring,
-            malcontent-data [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+            malcontent [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
 Suggests: gdm3,
 Description: Initial GNOME system setup helper
  After acquiring or installing a new system there are a few essential things


### PR DESCRIPTION
This reverts commit 3b0f7ff42e9df01897a44cb6acf70b1edefaa5f5. We're now
addressing the packaging delta with Debian and malcontent-data will no
longer exist.

https://phabricator.endlessm.com/T30746