### PR TITLE
Reintroduce most still-relevant downstream changes atop 43

### DIFF
--- a/data/20-gnome-initial-setup.rules.in
+++ b/data/20-gnome-initial-setup.rules.in
@@ -10,6 +10,7 @@ polkit.addRule(function(action, subject) {
         return undefined;
 
     var actionMatches = (action.id.indexOf('org.freedesktop.hostname1.') === 0 ||
+                         action.id === 'com.endlessm.Metrics.SetEnabled' ||
                          action.id.indexOf('org.freedesktop.NetworkManager.') === 0 ||
                          action.id.indexOf('org.freedesktop.locale1.') === 0 ||
                          action.id.indexOf('org.freedesktop.accounts.') === 0 ||

--- a/gnome-initial-setup/cc-common-language.c
+++ b/gnome-initial-setup/cc-common-language.c
@@ -34,6 +34,8 @@
 
 #include "cc-common-language.h"
 
+#include "gnome-initial-setup.h"
+
 static char *get_lang_for_user_object_path (const char *path);
 
 static char *current_language;
@@ -286,13 +288,44 @@ insert_user_languages (GHashTable *ht)
         }
 }
 
-GHashTable *
-cc_common_language_get_initial_languages (void)
+#define VENDOR_LANGUAGE_GROUP "Language"
+#define VENDOR_LANGUAGE_INITIAL_LANGUAGES_KEY "initial_languages"
+
+static gboolean
+insert_vendor_languages (GHashTable *ht)
 {
-        GHashTable *ht;
+        g_auto(GStrv) languages = NULL;
+        int idx;
+        GisDriver *driver;
 
-        ht = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+        /* This code will look for options under the "Language" group, and
+         * supports the following keys:
+         *   - initial_languages (optional): a string list of language codes to
+         *       pre-populate the initial list of languages
+         *
+         * For example, this is how this file would look on a vendor image defining
+         * a south-east Asian initial language list:
+         *
+         *   [Language]
+         *   initial_languages=id_ID.UTF-8;th_TH.UTF-8;vi_VN.UTF-8;hi_IN.UTF-8
+         */
+        driver = GIS_DRIVER (g_application_get_default ());
+        languages = gis_driver_conf_get_string_list (driver,
+                                                     VENDOR_LANGUAGE_GROUP,
+                                                     VENDOR_LANGUAGE_INITIAL_LANGUAGES_KEY,
+                                                     NULL);
+        if (languages == NULL)
+                return FALSE;
 
+        for (idx = 0; languages[idx] != NULL; idx++)
+                insert_language (ht, languages[idx]);
+
+        return TRUE;
+}
+
+static void
+insert_default_languages (GHashTable *ht)
+{
         insert_language (ht, "en_US.UTF-8");
 #if 0
         /* Having 9 languages in the list initially makes the window
@@ -309,6 +342,17 @@ cc_common_language_get_initial_languages (void)
         insert_language (ht, "ja_JP.UTF-8");
         insert_language (ht, "ru_RU.UTF-8");
         insert_language (ht, "ar_EG.UTF-8");
+}
+
+GHashTable *
+cc_common_language_get_initial_languages (void)
+{
+        GHashTable *ht;
+
+        ht = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+
+        if (!insert_vendor_languages (ht))
+                insert_default_languages (ht);
 
         insert_user_languages (ht);
 

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -961,6 +961,10 @@ gis_driver_startup (GApplication *app)
                                     "title", _("Initial Setup"),
                                     NULL);
 
+  gtk_application_inhibit (GTK_APPLICATION (app), driver->main_window,
+                           GTK_APPLICATION_INHIBIT_IDLE,
+                           "Should not be idle on first boot.");
+
   g_signal_connect (driver->main_window,
                     "realize",
                     G_CALLBACK (window_realize_cb),

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <locale.h>
 #include <stdlib.h>
+#include <gio/gunixmounts.h>
 
 #ifdef HAVE_WEBKITGTK_6_0
 #include <webkit/webkit.h>
@@ -35,6 +36,7 @@
 
 #include "cc-common-language.h"
 #include "gis-assistant.h"
+#include "gis-page-util.h"
 
 #define GIS_TYPE_DRIVER_MODE (gis_driver_mode_get_type ())
 
@@ -65,6 +67,8 @@ static guint signals[LAST_SIGNAL];
 
 typedef enum {
   PROP_MODE = 1,
+  PROP_LIVE_SESSION,
+  PROP_LIVE_PERSISTENCE,
   PROP_USERNAME,
   PROP_SMALL_SCREEN,
   PROP_PARENTAL_CONTROLS_ENABLED,
@@ -98,6 +102,10 @@ struct _GisDriver {
 
   GdkPaintable *avatar;  /* (owned) (nullable) */
 
+  gboolean is_live_session;
+  gboolean is_reformatter;
+  gboolean has_live_persistence;
+
   GisDriverMode mode;
   UmAccountMode account_mode;
   gboolean small_screen;
@@ -106,9 +114,126 @@ struct _GisDriver {
 
   const gchar *vendor_conf_file_path;
   GKeyFile *vendor_conf_file;
+
+  gchar *product_name;
 };
 
 G_DEFINE_TYPE (GisDriver, gis_driver, ADW_TYPE_APPLICATION)
+
+/* Should be kept in sync with eos-installer */
+static gboolean
+check_for_live_boot (gchar **uuid)
+{
+  const gchar *force = NULL;
+  GError *error = NULL;
+  g_autofree gchar *cmdline = NULL;
+  gboolean live_boot = FALSE;
+  g_autoptr(GRegex) reg = NULL;
+  g_autoptr(GMatchInfo) info = NULL;
+
+  g_return_val_if_fail (uuid != NULL, FALSE);
+
+  force = g_getenv ("EI_FORCE_LIVE_BOOT_UUID");
+  if (force != NULL && *force != '\0')
+    {
+      *uuid = g_strdup (force);
+      return TRUE;
+    }
+
+  if (!g_file_get_contents ("/proc/cmdline", &cmdline, NULL, &error))
+    {
+      g_error_free (error);
+      return FALSE;
+    }
+
+  live_boot = g_regex_match_simple ("\\bendless\\.live_boot\\b", cmdline, 0, 0);
+
+  reg = g_regex_new ("\\bendless\\.image\\.device=UUID=([^\\s]*)", 0, 0, NULL);
+  g_regex_match (reg, cmdline, 0, &info);
+  if (g_match_info_matches (info))
+    *uuid = g_match_info_fetch (info, 1);
+
+  return live_boot;
+}
+
+static gboolean
+running_live_session (void)
+{
+  g_autofree gchar *uuid = NULL;
+
+  if (!check_for_live_boot (&uuid))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+check_live_persistence (GisDriver *driver)
+{
+  g_autoptr(GUnixMountEntry) entry = NULL;
+
+  if (driver->is_live_session)
+    {
+      entry = g_unix_mount_at ("/run/eos-live", NULL);
+      driver->has_live_persistence = entry != NULL;
+    }
+  else
+    {
+      driver->has_live_persistence = FALSE;
+    }
+}
+
+#define EOS_IMAGE_VERSION_PATH "/sysroot"
+#define EOS_IMAGE_VERSION_ALT_PATH "/"
+
+static char *
+get_image_version (void)
+{
+  g_autoptr(GError) error_sysroot = NULL;
+  g_autoptr(GError) error_root = NULL;
+  char *image_version =
+    gis_page_util_get_image_version (EOS_IMAGE_VERSION_PATH, &error_sysroot);
+
+  if (image_version == NULL)
+    image_version =
+      gis_page_util_get_image_version (EOS_IMAGE_VERSION_ALT_PATH, &error_root);
+
+  if (image_version == NULL)
+    {
+      g_warning ("%s", error_sysroot->message);
+      g_warning ("%s", error_root->message);
+    }
+
+  return image_version;
+}
+
+static gboolean
+image_is_reformatter (const gchar *image_version)
+{
+  return image_version != NULL &&
+    g_str_has_prefix (image_version, "eosinstaller-");
+}
+
+static gchar *
+get_product_from_image_version (const gchar *image_version)
+{
+  gchar *hyphen_index = NULL;
+
+  if (image_version == NULL)
+    return NULL;
+
+  hyphen_index = index (image_version, '-');
+  if (hyphen_index == NULL)
+    return NULL;
+
+  return g_strndup (image_version, hyphen_index - image_version);
+}
+
+const gchar *
+gis_driver_get_product_name (GisDriver *driver)
+{
+  return driver->product_name;
+}
 
 static void
 gis_driver_dispose (GObject *object)
@@ -127,6 +252,7 @@ gis_driver_finalize (GObject *object)
 {
   GisDriver *driver = GIS_DRIVER (object);
 
+  g_free (driver->product_name);
   g_free (driver->lang_id);
   g_free (driver->username);
   g_free (driver->full_name);
@@ -470,6 +596,12 @@ gis_driver_add_page (GisDriver *driver,
 }
 
 void
+gis_driver_show_window (GisDriver *driver)
+{
+  gtk_window_present (driver->main_window);
+}
+
+void
 gis_driver_hide_window (GisDriver *driver)
 {
   gtk_widget_hide (GTK_WIDGET (driver->main_window));
@@ -589,6 +721,24 @@ gis_driver_get_mode (GisDriver *driver)
 }
 
 gboolean
+gis_driver_is_live_session (GisDriver *driver)
+{
+    return driver->is_live_session;
+}
+
+gboolean
+gis_driver_has_live_persistence (GisDriver *driver)
+{
+    return driver->has_live_persistence;
+}
+
+gboolean
+gis_driver_is_reformatter (GisDriver *driver)
+{
+  return driver->is_reformatter;
+}
+
+gboolean
 gis_driver_is_small_screen (GisDriver *driver)
 {
   return driver->small_screen;
@@ -616,6 +766,12 @@ gis_driver_get_property (GObject      *object,
 
   switch ((GisDriverProperty) prop_id)
     {
+    case PROP_LIVE_SESSION:
+      g_value_set_boolean (value, driver->is_live_session);
+      break;
+    case PROP_LIVE_PERSISTENCE:
+      g_value_set_boolean (value, driver->has_live_persistence);
+      break;
     case PROP_MODE:
       g_value_set_enum (value, driver->mode);
       break;
@@ -784,6 +940,7 @@ static void
 gis_driver_startup (GApplication *app)
 {
   GisDriver *driver = GIS_DRIVER (app);
+  g_autofree char *image_version = NULL;
 #if !WEBKIT_CHECK_VERSION(2, 39, 5)
   WebKitWebContext *context = webkit_web_context_get_default ();
 #endif
@@ -812,6 +969,17 @@ gis_driver_startup (GApplication *app)
   driver->assistant = g_object_new (GIS_TYPE_ASSISTANT, NULL);
   gtk_window_set_child (GTK_WINDOW (driver->main_window),
                         GTK_WIDGET (driver->assistant));
+
+  image_version = get_image_version ();
+  driver->product_name = get_product_from_image_version (image_version);
+
+  driver->is_live_session = running_live_session ();
+  g_object_notify_by_pspec (G_OBJECT (driver), obj_props[PROP_LIVE_SESSION]);
+
+  check_live_persistence (driver);
+  g_object_notify_by_pspec (G_OBJECT (driver), obj_props[PROP_LIVE_PERSISTENCE]);
+
+  driver->is_reformatter = image_is_reformatter (image_version);
 
   gis_driver_set_user_language (driver, setlocale (LC_MESSAGES, NULL), FALSE);
 
@@ -853,6 +1021,16 @@ gis_driver_class_init (GisDriverClass *klass)
                   0,
                   NULL, NULL, NULL,
                   G_TYPE_NONE, 0);
+
+  obj_props[PROP_LIVE_SESSION] =
+    g_param_spec_boolean ("live-session", "", "",
+                          FALSE,
+                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_LIVE_PERSISTENCE] =
+    g_param_spec_boolean ("live-persistence", "", "",
+                          FALSE,
+                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
   obj_props[PROP_MODE] =
     g_param_spec_enum ("mode", "", "",

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -70,6 +70,7 @@ typedef enum {
   PROP_LIVE_SESSION,
   PROP_LIVE_PERSISTENCE,
   PROP_USERNAME,
+  PROP_PASSWORDLESS,
   PROP_SMALL_SCREEN,
   PROP_PARENTAL_CONTROLS_ENABLED,
   PROP_FULL_NAME,
@@ -99,6 +100,7 @@ struct _GisDriver {
   gchar *lang_id;
   gchar *username;
   gchar *full_name;  /* (owned) (nullable) */
+  gboolean passwordless;
 
   GdkPaintable *avatar;  /* (owned) (nullable) */
 
@@ -458,6 +460,22 @@ gis_driver_get_avatar (GisDriver *driver)
 }
 
 void
+gis_driver_set_passwordless (GisDriver *self,
+                             gboolean   passwordless)
+{
+  gboolean should_notify = (self->passwordless != passwordless);
+  self->passwordless = passwordless;
+  if (should_notify)
+    g_object_notify (G_OBJECT (self), "passwordless");
+}
+
+gboolean
+gis_driver_get_passwordless (GisDriver *self)
+{
+  return self->passwordless;
+}
+
+void
 gis_driver_set_user_permissions (GisDriver   *driver,
                                  ActUser     *user,
                                  const gchar *password)
@@ -778,6 +796,9 @@ gis_driver_get_property (GObject      *object,
     case PROP_USERNAME:
       g_value_set_string (value, driver->username);
       break;
+    case PROP_PASSWORDLESS:
+      g_value_set_boolean (value, driver->passwordless);
+      break;
     case PROP_SMALL_SCREEN:
       g_value_set_boolean (value, driver->small_screen);
       break;
@@ -812,6 +833,9 @@ gis_driver_set_property (GObject      *object,
     case PROP_USERNAME:
       g_free (driver->username);
       driver->username = g_value_dup_string (value);
+      break;
+    case PROP_PASSWORDLESS:
+      driver->passwordless = g_value_get_boolean (value);
       break;
     case PROP_PARENTAL_CONTROLS_ENABLED:
       gis_driver_set_parental_controls_enabled (driver, g_value_get_boolean (value));
@@ -1046,6 +1070,11 @@ gis_driver_class_init (GisDriverClass *klass)
     g_param_spec_string ("username", "", "",
                          NULL,
                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  obj_props[PROP_PASSWORDLESS] =
+    g_param_spec_boolean ("passwordless", "", "Main user account is passwordless",
+                          FALSE,
+                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
   obj_props[PROP_SMALL_SCREEN] =
     g_param_spec_boolean ("small-screen", "", "",

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -91,6 +91,11 @@ void gis_driver_set_avatar (GisDriver    *driver,
                             GdkPaintable *avatar);
 GdkPaintable *gis_driver_get_avatar (GisDriver *driver);
 
+void gis_driver_set_passwordless (GisDriver *self,
+                                  gboolean   passwordless);
+
+gboolean gis_driver_get_passwordless (GisDriver *self);
+
 gboolean gis_driver_get_gdm_objects (GisDriver        *driver,
                                      GdmGreeter      **greeter,
                                      GdmUserVerifier **user_verifier);

--- a/gnome-initial-setup/gis-driver.h
+++ b/gnome-initial-setup/gis-driver.h
@@ -97,10 +97,20 @@ gboolean gis_driver_get_gdm_objects (GisDriver        *driver,
 
 GisDriverMode gis_driver_get_mode (GisDriver *driver);
 
+gboolean gis_driver_is_live_session (GisDriver *driver);
+
+gboolean gis_driver_has_live_persistence (GisDriver *driver);
+
+gboolean gis_driver_is_reformatter (GisDriver *driver);
+
 gboolean gis_driver_is_small_screen (GisDriver *driver);
+
+const gchar *gis_driver_get_product_name (GisDriver *driver);
 
 void gis_driver_add_page (GisDriver *driver,
                           GisPage   *page);
+
+void gis_driver_show_window (GisDriver *driver);
 
 void gis_driver_hide_window (GisDriver *driver);
 

--- a/gnome-initial-setup/gis-page-util.c
+++ b/gnome-initial-setup/gis-page-util.c
@@ -1,0 +1,67 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Endless Mobile, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ *
+ * Written by:
+ *     Mario Sanchez Prada <mario@endlessm.com>
+ */
+
+#include "config.h"
+
+#include "gis-page-util.h"
+
+#include <errno.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+
+#define EOS_IMAGE_VERSION_XATTR "user.eos-image-version"
+
+gchar *
+gis_page_util_get_image_version (const gchar *path,
+                                 GError     **error)
+{
+  ssize_t attrsize;
+  g_autofree gchar *value = NULL;
+
+  g_return_val_if_fail (path != NULL, NULL);
+
+  attrsize = getxattr (path, EOS_IMAGE_VERSION_XATTR, NULL, 0);
+  if (attrsize >= 0)
+    {
+      value = g_malloc (attrsize + 1);
+      value[attrsize] = 0;
+
+      attrsize = getxattr (path, EOS_IMAGE_VERSION_XATTR, value,
+                           attrsize);
+    }
+
+  if (attrsize >= 0)
+    {
+      return g_steal_pointer (&value);
+    }
+  else
+    {
+      int errsv = errno;
+      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errsv),
+                   "Error examining " EOS_IMAGE_VERSION_XATTR " on %s: %s",
+                   path, g_strerror (errsv));
+      return NULL;
+    }
+}

--- a/gnome-initial-setup/gis-page-util.h
+++ b/gnome-initial-setup/gis-page-util.h
@@ -1,0 +1,36 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Endless Mobile, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ *
+ * Written by:
+ *     Mario Sanchez Prada <mario@endlessm.com>
+ */
+
+#ifndef __GIS_PAGE_UTIL_H__
+#define __GIS_PAGE_UTIL_H__
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gchar *gis_page_util_get_image_version (const gchar *path,
+                                        GError     **error);
+
+G_END_DECLS
+
+#endif

--- a/gnome-initial-setup/meson.build
+++ b/gnome-initial-setup/meson.build
@@ -13,6 +13,7 @@ sources += [
     'gis-assistant.c',
     'gis-page.c',
     'gis-page-header.c',
+    'gis-page-util.c',
     'gis-pkexec.c',
     'gis-driver.c',
     'gis-keyring.c',
@@ -20,6 +21,7 @@ sources += [
     'gis-assistant.h',
     'gis-page.h',
     'gis-page-header.h',
+    'gis-page-util.h',
     'gis-pkexec.h',
     'gis-driver.h',
     'gis-keyring.h'

--- a/gnome-initial-setup/meson.build
+++ b/gnome-initial-setup/meson.build
@@ -50,6 +50,7 @@ dependencies = [
     geocode_glib_2_dep,
     dependency ('gnome-desktop-4'),
     dependency ('gsettings-desktop-schemas', version: '>= 3.37.1'),
+    dependency ('eosmetrics-0', version: '>= 0.5.0'),
     dependency ('fontconfig'),
     dependency ('goa-1.0'),
     dependency ('gtk4', version: '>= 4.6'),

--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -56,6 +56,8 @@ struct _GisAccountPageLocal
   GtkWidget *enable_parental_controls_check_button;
   gboolean   has_custom_username;
   GtkWidget *username_explanation;
+  GtkWidget *password_toggle;
+  gboolean   passwordless;
   UmPhotoDialog *photo_dialog;
 
   gint timeout_id;
@@ -280,6 +282,8 @@ validate (GisAccountPageLocal *page)
 
   um_photo_dialog_generate_avatar (page->photo_dialog, name);
 
+  page->passwordless = !gtk_check_button_get_active (GTK_CHECK_BUTTON (page->password_toggle));
+
   validation_changed (page);
 
   return G_SOURCE_REMOVE;
@@ -443,6 +447,8 @@ gis_account_page_local_constructed (GObject *object)
                             "activate", G_CALLBACK (confirm), page);
   g_signal_connect_swapped (page->fullname_entry, "activate",
                             G_CALLBACK (confirm), page);
+  g_signal_connect_swapped (page->password_toggle, "toggled",
+                            G_CALLBACK (validate), page);
   g_signal_connect (page->enable_parental_controls_check_button, "toggled",
                     G_CALLBACK (enable_parental_controls_check_button_toggled_cb), page);
 
@@ -611,6 +617,9 @@ local_create_user (GisAccountPageLocal  *local,
 
   set_user_avatar (local, main_user);
 
+  if (local->passwordless)
+    act_user_set_password_mode (main_user, ACT_USER_PASSWORD_MODE_NONE);
+
   g_signal_emit (local, signals[MAIN_USER_CREATED], 0, main_user, "");
 
   return TRUE;
@@ -629,6 +638,7 @@ gis_account_page_local_class_init (GisAccountPageLocalClass *klass)
   gtk_widget_class_bind_template_child (GTK_WIDGET_CLASS (klass), GisAccountPageLocal, fullname_entry);
   gtk_widget_class_bind_template_child (GTK_WIDGET_CLASS (klass), GisAccountPageLocal, username_combo);
   gtk_widget_class_bind_template_child (GTK_WIDGET_CLASS (klass), GisAccountPageLocal, username_explanation);
+  gtk_widget_class_bind_template_child (GTK_WIDGET_CLASS (klass), GisAccountPageLocal, password_toggle);
   gtk_widget_class_bind_template_child (GTK_WIDGET_CLASS (klass), GisAccountPageLocal, enable_parental_controls_box);
   gtk_widget_class_bind_template_child (GTK_WIDGET_CLASS (klass), GisAccountPageLocal, enable_parental_controls_check_button);
 

--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -691,6 +691,7 @@ gis_account_page_local_apply (GisAccountPageLocal *local, GisPage *page)
 
   username = gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (local->username_combo));
   gis_driver_set_username (GIS_PAGE (page)->driver, username);
+  gis_driver_set_passwordless (page->driver, local->passwordless);
 
   full_name = gtk_editable_get_text (GTK_EDITABLE (local->fullname_entry));
   gis_driver_set_full_name (GIS_PAGE (page)->driver, full_name);

--- a/gnome-initial-setup/pages/account/gis-account-page-local.c
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.c
@@ -311,6 +311,7 @@ fullname_changed (GtkWidget      *w,
 
   if ((name == NULL || strlen (name) == 0) && !page->has_custom_username) {
     gtk_editable_set_text (GTK_EDITABLE (entry), "");
+    generate_username_choices ("", GTK_LIST_STORE (model));
   }
   else if (name != NULL && strlen (name) != 0) {
     generate_username_choices (name, GTK_LIST_STORE (model));

--- a/gnome-initial-setup/pages/account/gis-account-page-local.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.ui
@@ -108,11 +108,21 @@
               </object>
             </child>
             <child>
+              <object class="GtkCheckButton" id="password_toggle">
+                <property name="visible">True</property>
+                <property name="label" translatable="yes">Set a password</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">6</property>
+                </layout>
+              </object>
+            </child>
+            <child>
               <object class="GtkBox" id="enable_parental_controls_box">
                 <property name="orientation">vertical</property>
                 <layout>
                   <property name="column">1</property>
-                  <property name="row">6</property>
+                  <property name="row">7</property>
                 </layout>
                 <child>
                   <object class="GtkCheckButton" id="enable_parental_controls_check_button">

--- a/gnome-initial-setup/pages/account/gis-account-page-local.ui
+++ b/gnome-initial-setup/pages/account/gis-account-page-local.ui
@@ -52,7 +52,7 @@
             </child>
             <child>
               <object class="GtkEntry" id="fullname_entry">
-                <property name="max_length">255</property>
+                <property name="max_length">80</property>
                 <property name="width-chars">25</property>
                 <layout>
                   <property name="column">1</property>

--- a/gnome-initial-setup/pages/account/um-utils.c
+++ b/gnome-initial-setup/pages/account/um-utils.c
@@ -33,6 +33,8 @@
 
 #include "um-utils.h"
 
+#define DEFAULT_USERNAME "user"
+
 void
 set_entry_validation_checkmark (GtkEntry *entry)
 {
@@ -180,6 +182,7 @@ generate_username_choices (const gchar  *name,
 {
         gboolean in_use, same_as_initial;
         char *lc_name, *ascii_name, *stripped_name;
+        char *default_username;
         char **words1;
         char **words2 = NULL;
         char **w1, **w2;
@@ -189,7 +192,7 @@ generate_username_choices (const gchar  *name,
         GString *item0, *item1, *item2, *item3, *item4;
         int len;
         int nwords1, nwords2, i;
-        GHashTable *items;
+        GHashTable *items = NULL;
         GtkTreeIter iter;
 
         gtk_list_store_clear (store);
@@ -223,7 +226,7 @@ generate_username_choices (const gchar  *name,
                 g_free (ascii_name);
                 g_free (lc_name);
                 g_free (stripped_name);
-                return;
+                goto bailout;
         }
 
         /* we split name on spaces, and then on dashes, so that we can treat
@@ -318,26 +321,68 @@ generate_username_choices (const gchar  *name,
 
         items = g_hash_table_new (g_str_hash, g_str_equal);
 
-        in_use = is_username_used (item0->str);
-        if (!in_use && !g_ascii_isdigit (item0->str[0])) {
-                gtk_list_store_append (store, &iter);
-                gtk_list_store_set (store, &iter, 0, item0->str, -1);
-                g_hash_table_insert (items, item0->str, item0->str);
+        /* shorten names */
+        if (strlen (first_word->str) > MAXNAMELEN) {
+                first_word->str[MAXNAMELEN] = '\0';
+        }
+        if (strlen (last_word->str) > MAXNAMELEN) {
+                last_word->str[MAXNAMELEN] = '\0';
         }
 
-        in_use = is_username_used (item1->str);
-        same_as_initial = (g_strcmp0 (item0->str, item1->str) == 0);
-        if (!same_as_initial && nwords2 > 0 && !in_use && !g_ascii_isdigit (item1->str[0])) {
-                gtk_list_store_append (store, &iter);
-                gtk_list_store_set (store, &iter, 0, item1->str, -1);
-                g_hash_table_insert (items, item1->str, item1->str);
+        if (strlen (item0->str) > MAXNAMELEN) {
+                item0->str[MAXNAMELEN] = '\0';
+        }
+        if (strlen (item1->str) > MAXNAMELEN) {
+                item1->str[MAXNAMELEN] = '\0';
+        }
+        if (strlen (item2->str) > MAXNAMELEN) {
+                item2->str[MAXNAMELEN] = '\0';
+        }
+        if (strlen (item3->str) > MAXNAMELEN) {
+                item3->str[MAXNAMELEN] = '\0';
+        }
+        if (strlen (item4->str) > MAXNAMELEN) {
+                item4->str[MAXNAMELEN] = '\0';
         }
 
-        /* if there's only one word, would be the same as item1 */
+        /* add the first one */
+        in_use = is_username_used (first_word->str);
+        if (*first_word->str && !in_use && !g_ascii_isdigit (first_word->str[0]) &&
+            !g_hash_table_lookup (items, first_word->str)) {
+                gtk_list_store_append (store, &iter);
+                gtk_list_store_set (store, &iter, 0, first_word->str, -1);
+                g_hash_table_insert (items, first_word->str, first_word->str);
+        }
+
+        /* if there's only one word, would be the same as first word */
         if (nwords2 > 1) {
+                /* add the last word */
+                in_use = is_username_used (last_word->str);
+                if (*last_word->str && !in_use && !g_ascii_isdigit (last_word->str[0]) &&
+                    !g_hash_table_lookup (items, last_word->str)) {
+                        gtk_list_store_append (store, &iter);
+                        gtk_list_store_set (store, &iter, 0, last_word->str, -1);
+                        g_hash_table_insert (items, last_word->str, last_word->str);
+                }
+
                 /* add other items */
+                in_use = is_username_used (item0->str);
+                if (*item0->str && !in_use && !g_ascii_isdigit (item0->str[0])) {
+                        gtk_list_store_append (store, &iter);
+                        gtk_list_store_set (store, &iter, 0, item0->str, -1);
+                        g_hash_table_insert (items, item0->str, item0->str);
+                }
+
+                in_use = is_username_used (item1->str);
+                same_as_initial = (g_strcmp0 (item0->str, item1->str) == 0);
+                if (*item1->str && !same_as_initial && nwords2 > 0 && !in_use && !g_ascii_isdigit (item1->str[0])) {
+                        gtk_list_store_append (store, &iter);
+                        gtk_list_store_set (store, &iter, 0, item1->str, -1);
+                        g_hash_table_insert (items, item1->str, item1->str);
+                }
+
                 in_use = is_username_used (item2->str);
-                if (!in_use && !g_ascii_isdigit (item2->str[0]) &&
+                if (*item2->str && !in_use && !g_ascii_isdigit (item2->str[0]) &&
                     !g_hash_table_lookup (items, item2->str)) {
                         gtk_list_store_append (store, &iter);
                         gtk_list_store_set (store, &iter, 0, item2->str, -1);
@@ -345,7 +390,7 @@ generate_username_choices (const gchar  *name,
                 }
 
                 in_use = is_username_used (item3->str);
-                if (!in_use && !g_ascii_isdigit (item3->str[0]) &&
+                if (*item3->str && !in_use && !g_ascii_isdigit (item3->str[0]) &&
                     !g_hash_table_lookup (items, item3->str)) {
                         gtk_list_store_append (store, &iter);
                         gtk_list_store_set (store, &iter, 0, item3->str, -1);
@@ -353,33 +398,14 @@ generate_username_choices (const gchar  *name,
                 }
 
                 in_use = is_username_used (item4->str);
-                if (!in_use && !g_ascii_isdigit (item4->str[0]) &&
+                if (*item4->str && !in_use && !g_ascii_isdigit (item4->str[0]) &&
                     !g_hash_table_lookup (items, item4->str)) {
                         gtk_list_store_append (store, &iter);
                         gtk_list_store_set (store, &iter, 0, item4->str, -1);
                         g_hash_table_insert (items, item4->str, item4->str);
                 }
-
-                /* add the last word */
-                in_use = is_username_used (last_word->str);
-                if (!in_use && !g_ascii_isdigit (last_word->str[0]) &&
-                    !g_hash_table_lookup (items, last_word->str)) {
-                        gtk_list_store_append (store, &iter);
-                        gtk_list_store_set (store, &iter, 0, last_word->str, -1);
-                        g_hash_table_insert (items, last_word->str, last_word->str);
-                }
-
-                /* ...and the first one */
-                in_use = is_username_used (first_word->str);
-                if (!in_use && !g_ascii_isdigit (first_word->str[0]) &&
-                    !g_hash_table_lookup (items, first_word->str)) {
-                        gtk_list_store_append (store, &iter);
-                        gtk_list_store_set (store, &iter, 0, first_word->str, -1);
-                        g_hash_table_insert (items, first_word->str, first_word->str);
-                }
         }
 
-        g_hash_table_destroy (items);
         g_strfreev (words1);
         g_string_free (first_word, TRUE);
         g_string_free (last_word, TRUE);
@@ -388,6 +414,22 @@ generate_username_choices (const gchar  *name,
         g_string_free (item2, TRUE);
         g_string_free (item3, TRUE);
         g_string_free (item4, TRUE);
+
+ bailout:
+        if (items == NULL || g_hash_table_size (items) == 0) {
+                gtk_list_store_append (store, &iter);
+                default_username = g_strdup (DEFAULT_USERNAME);
+                i = 0;
+                while (is_username_used (default_username)) {
+                        g_free (default_username);
+                        default_username = g_strdup_printf (DEFAULT_USERNAME "%d", ++i);
+                }
+                gtk_list_store_set (store, &iter, 0, default_username, -1);
+                g_free (default_username);
+        }
+        if (items != NULL) {
+                g_hash_table_destroy (items);
+        }
 }
 
 #define IMAGE_SIZE 512

--- a/gnome-initial-setup/pages/account/um-utils.c
+++ b/gnome-initial-setup/pages/account/um-utils.c
@@ -86,6 +86,7 @@ is_valid_name (const gchar *name)
         /* Valid names must contain:
          *   1) at least one character.
          *   2) at least one non-"space" character.
+         *   3) no more than 80 bytes (see https://phabricator.endlessm.com/T25444).
          */
         for (c = name; *c; c++) {
                 gunichar unichar;
@@ -103,7 +104,8 @@ is_valid_name (const gchar *name)
                 }
         }
 
-        return !is_empty;
+        /* Here we check the number of bytes not characters */
+        return !is_empty && strlen (name) < 80;
 }
 
 gboolean

--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -334,7 +334,7 @@ no_results_widget_new (void)
         return widget;
 }
 
-static void
+static int
 add_rows_to_list (CcInputChooser  *chooser,
 	          GList            *list,
 	          const gchar      *type,
@@ -345,6 +345,7 @@ add_rows_to_list (CcInputChooser  *chooser,
 	const gchar *id;
 	GtkWidget *widget;
 	gchar *key;
+	int rows_added = 0;
 
 	for (; list; list = list->next) {
 		id = (const gchar *) list->data;
@@ -358,6 +359,7 @@ add_rows_to_list (CcInputChooser  *chooser,
 			continue;
 		}
 		g_hash_table_add (priv->inputs, key);
+		rows_added++;
 
 		if (g_hash_table_size (priv->inputs) > MIN_ROWS)
 			is_extra = TRUE;
@@ -365,9 +367,11 @@ add_rows_to_list (CcInputChooser  *chooser,
 		g_ptr_array_add (priv->input_widget_boxes, g_object_ref_sink (widget));
 		gtk_list_box_append (GTK_LIST_BOX (priv->input_list), widget);
 	}
+
+	return rows_added;
 }
 
-static void
+static int
 add_row_to_list (CcInputChooser *chooser,
 		 const gchar     *type,
 		 const gchar     *id,
@@ -375,7 +379,7 @@ add_row_to_list (CcInputChooser *chooser,
 {
 	GList tmp = { 0 };
 	tmp.data = (gpointer)id;
-	add_rows_to_list (chooser, &tmp, type, NULL, is_extra);
+	return add_rows_to_list (chooser, &tmp, type, NULL, is_extra);
 }
 
 static void
@@ -386,9 +390,10 @@ get_locale_infos (CcInputChooser *chooser)
 	const gchar *id = NULL;
 	gchar *lang, *country;
 	GList *list;
+	int non_extra_layouts = 0;
 
 	if (gnome_get_input_source_from_locale (priv->locale, &type, &id)) {
-                add_row_to_list (chooser, type, id, FALSE);
+                non_extra_layouts += add_row_to_list (chooser, type, id, FALSE);
 		if (!priv->id) {
 			priv->id = g_strdup (id);
 			priv->type = g_strdup (type);
@@ -399,13 +404,21 @@ get_locale_infos (CcInputChooser *chooser)
 		goto out;
 
 	list = gnome_xkb_info_get_layouts_for_language (priv->xkb_info, lang);
-	add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
+	non_extra_layouts += add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
 	g_list_free (list);
 
 	if (country != NULL) {
 		list = gnome_xkb_info_get_layouts_for_country (priv->xkb_info, country);
-		add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
+		non_extra_layouts += add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
 		g_list_free (list);
+	}
+
+	/* Add default us and us+intl non-extra layouts in case we could not
+	 * find anything more specific.
+	 */
+	if (non_extra_layouts == 0) {
+		add_row_to_list (chooser, INPUT_SOURCE_TYPE_XKB, "us", FALSE);
+		add_row_to_list (chooser, INPUT_SOURCE_TYPE_XKB, "us+intl", FALSE);
 	}
 
 	list = gnome_xkb_info_get_all_layouts (priv->xkb_info);

--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -433,6 +433,8 @@ input_visible (GtkListBoxRow *row,
                 return !priv->showing_extra && g_hash_table_size (priv->inputs) > MIN_ROWS;
 
         widget = get_input_widget (child);
+        if (g_strcmp0 (priv->id, widget->id) == 0)
+                return TRUE;
 
         if (!priv->showing_extra && widget->is_extra)
                 return FALSE;

--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -482,6 +482,8 @@ sort_inputs (GtkListBoxRow *a,
                 gpointer       data)
 {
         InputWidget *la, *lb;
+        CcInputChooser *chooser = data;
+        CcInputChooserPrivate *priv = cc_input_chooser_get_instance_private (chooser);
 
         la = get_input_widget (gtk_list_box_row_get_child (a));
         lb = get_input_widget (gtk_list_box_row_get_child (b));
@@ -491,6 +493,12 @@ sort_inputs (GtkListBoxRow *a,
 
         if (lb == NULL)
                 return -1;
+
+        if (g_strcmp0 (priv->id, la->id) == 0)
+                return -1;
+
+        if (g_strcmp0 (priv->id, lb->id) == 0)
+                return 1;
 
         if (la->is_extra && !lb->is_extra)
                 return 1;

--- a/gnome-initial-setup/pages/language/cc-language-chooser.c
+++ b/gnome-initial-setup/pages/language/cc-language-chooser.c
@@ -478,6 +478,7 @@ cc_language_chooser_constructed (GObject *object)
                 priv->language = cc_common_language_get_current_language ();
 
         sync_all_checkmarks (chooser);
+        show_more (chooser);
 }
 
 static void

--- a/gnome-initial-setup/pages/language/cc-language-chooser.c
+++ b/gnome-initial-setup/pages/language/cc-language-chooser.c
@@ -47,6 +47,7 @@ struct _CcLanguageChooserPrivate
 
         gboolean showing_extra;
         gchar *language;
+        gchar *initial_language;
 };
 typedef struct _CcLanguageChooserPrivate CcLanguageChooserPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE (CcLanguageChooser, cc_language_chooser, GTK_TYPE_BOX);
@@ -348,6 +349,8 @@ sort_languages (GtkListBoxRow *a,
                 GtkListBoxRow *b,
                 gpointer       data)
 {
+        CcLanguageChooser *chooser = data;
+        CcLanguageChooserPrivate *priv = cc_language_chooser_get_instance_private (chooser);
         LanguageWidget *la, *lb;
         int ret;
 
@@ -359,6 +362,12 @@ sort_languages (GtkListBoxRow *a,
 
         if (lb == NULL)
                 return -1;
+
+        if (g_strcmp0 (la->locale_id, priv->initial_language) == 0)
+                return -1;
+
+        if (g_strcmp0 (lb->locale_id, priv->initial_language) == 0)
+                return 1;
 
         if (la->is_extra && !lb->is_extra)
                 return 1;
@@ -465,6 +474,11 @@ cc_language_chooser_constructed (GObject *object)
                                       language_visible, chooser, NULL);
         gtk_list_box_set_selection_mode (GTK_LIST_BOX (priv->language_list),
                                          GTK_SELECTION_NONE);
+
+        if (priv->language == NULL)
+                priv->language = cc_common_language_get_current_language ();
+        priv->initial_language = g_strdup (priv->language);
+
         add_all_languages (chooser);
 
         g_signal_connect (priv->filter_entry, "changed",
@@ -473,9 +487,6 @@ cc_language_chooser_constructed (GObject *object)
 
         g_signal_connect (priv->language_list, "row-activated",
                           G_CALLBACK (row_activated), chooser);
-
-        if (priv->language == NULL)
-                priv->language = cc_common_language_get_current_language ();
 
         sync_all_checkmarks (chooser);
         show_more (chooser);
@@ -488,6 +499,7 @@ cc_language_chooser_finalize (GObject *object)
         CcLanguageChooserPrivate *priv = cc_language_chooser_get_instance_private (chooser);
 
         g_free (priv->language);
+        g_free (priv->initial_language);
 
 	G_OBJECT_CLASS (cc_language_chooser_parent_class)->finalize (object);
 }

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -191,6 +191,7 @@ update_distro_logo (GisLanguagePage *page)
     const char *logo;
   } id_to_logo[] = {
     { "debian",                         "emblem-debian" },
+    { "endless",                        "endlessos" },
     { "fedora",                         "fedora-logo-icon" },
     { "ubuntu",                         "ubuntu-logo-icon" },
     { "openSUSE Tumbleweed",            "opensuse-logo-icon" },

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.c
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.c
@@ -82,6 +82,8 @@ struct _GisTimezonePagePrivate
   GSettings *clock_settings;
   gboolean in_search;
 
+  gboolean show_if_detected;
+
   gulong search_entry_text_changed_id;
 };
 typedef struct _GisTimezonePagePrivate GisTimezonePagePrivate;
@@ -142,6 +144,11 @@ set_location (GisTimezonePage  *page,
       tzid = g_time_zone_get_identifier (zone);
 
       cc_timezone_map_set_timezone (CC_TIMEZONE_MAP (priv->map), tzid);
+
+      /* If the page hasn't yet been shown and we found the timezone
+       * automatically, then don't show the page */
+      if (!priv->show_if_detected)
+        gtk_widget_hide (GTK_WIDGET (page));
 
       /* If this location is manually set, stop waiting for geolocation. */
       if (!priv->in_geoclue_callback)
@@ -487,6 +494,17 @@ gis_timezone_page_locale_changed (GisPage *page)
   gis_page_set_title (GIS_PAGE (page), _("Time Zone"));
 }
 
+static void
+gis_timezone_page_shown (GisPage *page)
+{
+  GisTimezonePage *tz_page = GIS_TIMEZONE_PAGE (page);
+  GisTimezonePagePrivate *priv = gis_timezone_page_get_instance_private (tz_page);
+
+  /* After the page has been shown already, don't hide it even if the location
+   * is detected */
+  priv->show_if_detected = TRUE;
+}
+
 static gboolean
 gis_timezone_page_apply (GisPage      *page,
                          GCancellable *cancellable)
@@ -514,6 +532,7 @@ gis_timezone_page_class_init (GisTimezonePageClass *klass)
 
   page_class->page_id = PAGE_ID;
   page_class->locale_changed = gis_timezone_page_locale_changed;
+  page_class->shown = gis_timezone_page_shown;
   page_class->apply = gis_timezone_page_apply;
   object_class->constructed = gis_timezone_page_constructed;
   object_class->dispose = gis_timezone_page_dispose;

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.c
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.c
@@ -79,7 +79,7 @@ struct _GisTimezonePagePrivate
   GCancellable *dtm_cancellable;
 
   GnomeWallClock *clock;
-  GDesktopClockFormat clock_format;
+  GSettings *clock_settings;
   gboolean in_search;
 
   gulong search_entry_text_changed_id;
@@ -288,9 +288,12 @@ update_timezone (GisTimezonePage *page, TzLocation *location)
   char *time_label;
   GTimeZone *zone;
   GDateTime *date;
+  GDesktopClockFormat clock_format;
   gboolean use_ampm;
 
-  if (priv->clock_format == G_DESKTOP_CLOCK_FORMAT_12H)
+  clock_format = g_settings_get_enum (priv->clock_settings, CLOCK_FORMAT_KEY);
+
+  if (clock_format == G_DESKTOP_CLOCK_FORMAT_12H)
     use_ampm = TRUE;
   else
     use_ampm = FALSE;
@@ -418,7 +421,6 @@ gis_timezone_page_constructed (GObject *object)
   GisTimezonePage *page = GIS_TIMEZONE_PAGE (object);
   GisTimezonePagePrivate *priv = gis_timezone_page_get_instance_private (page);
   GError *error;
-  GSettings *settings;
 
   G_OBJECT_CLASS (gis_timezone_page_parent_class)->constructed (object);
 
@@ -439,9 +441,7 @@ gis_timezone_page_constructed (GObject *object)
   priv->clock = g_object_new (GNOME_TYPE_WALL_CLOCK, NULL);
   g_signal_connect (priv->clock, "notify::clock", G_CALLBACK (on_clock_changed), page);
 
-  settings = g_settings_new (CLOCK_SCHEMA);
-  priv->clock_format = g_settings_get_enum (settings, CLOCK_FORMAT_KEY);
-  g_object_unref (settings);
+  priv->clock_settings = g_settings_new (CLOCK_SCHEMA);
 
   set_location (page, NULL);
 
@@ -454,6 +454,8 @@ gis_timezone_page_constructed (GObject *object)
                     G_CALLBACK (entry_mapped), page);
   g_signal_connect (priv->map, "location-changed",
                     G_CALLBACK (map_location_changed), page);
+  g_signal_connect (priv->clock_settings, "notify::" CLOCK_FORMAT_KEY,
+                    G_CALLBACK (update_timezone), page);
 
   gtk_widget_show (GTK_WIDGET (page));
 }
@@ -474,6 +476,7 @@ gis_timezone_page_dispose (GObject *object)
 
   g_clear_object (&priv->dtm);
   g_clear_object (&priv->clock);
+  g_clear_object (&priv->clock_settings);
 
   G_OBJECT_CLASS (gis_timezone_page_parent_class)->dispose (object);
 }

--- a/meson.build
+++ b/meson.build
@@ -68,7 +68,7 @@ libadwaita_dep = dependency(
 
 # Needed for the parental controls pages
 libmalcontent_dep = dependency ('malcontent-0',
-                                version: '>= 0.6.0',
+                                version: '>= 0.7.0',
                                 required: get_option('parental_controls'))
 libmalcontent_ui_dep = dependency ('malcontent-ui-1',
                                    version: '>= 0.11.0',


### PR DESCRIPTION
This reintroduces the majority of our downstream functionality from eos5.1 that we want to preserve. There are 3½ conspicuous gaps:

- factory dialog, accessed by pressing Ctrl+f on the first page
- live boot support & invoking eos-installer on eosinstaller images (which are entwined)
- the eula page
- transifex goop

I'll bring these back in later PRs but they are more involved than the other changes, due to the GTK 4 port.

I first rebased our existing changes onto the latest 41.x point release, not because I plan to merge that rebase but because helped apply them to this new baseline. I have made notes on what I dropped, squashed, and split on the following PR:

- https://github.com/endlessm/gnome-initial-setup/pull/343

So this PR is the result of rebasing that series onto `master`. It depends on the following:

- [ ] https://github.com/endlessm/gnome-initial-setup/pull/342

https://phabricator.endlessm.com/T35040

Picked
------

5d81bdcc copypasta code: Use GTask in UmRealmManager

- No conflicts.

a2672e30 Allow initial setup to switch metrics on and off

- Applied without conflicts

539bb54f language: List 'endless' in the id-to-logo mapping array

- Applied without conflicts

18d4a1e3 account-local: limit full name to 80 characters

- Applied without conflicts

23f1bbcd account-local: username suggestions

- Resolved one minor conflict due to GTK 4 port.

bfd80ac4 page-util: Add API to read the EOS image version

- Applied without conflict

d38138f8 driver: Track details of current image & boot type

- Fixed minor conflicts

930c0fea input-chooser: sort default layout before others

- Applied without conflicts.

954c2c21 input-chooser: consider only language or country layouts non-extra

- Fixed minor conflicts.
- It's actually pretty hard to find a locale with fewer than 5 language/country
  layouts. Macedonian is one.
- This patch actually has no effect – choose_non_extras() is already called
  before adding the massive list of other layouts - but it is cleaner. So should go upstream. Rewording commit message accordingly.

1c44d429 input-chooser: Always show the selected layout

- Applied without conflicts
- I'm not 100% sure this patch does anything though

384f5c91 keyboard: add us/us+intl default layouts as fallback

- Applied without conflicts

8cc19caa language-chooser: make it more clear for the users

The previous version of this patch professes to do the following:

1. Vertically centre the initially-selected language – not needed, the initial
   language is always in the group that sits “above the fold”. I think an
   earlier iteration just showed all languages in alphabetical order rather than
   showing the cherry-picked list of 8 languages plus the current locale.

2. Show the searchbar by default – no longer needed, the search bar is always
   shown by default.

3. Show all languages by default because it is not clear that the
   three-vertical-dots row means "show the other languages". I have to say I am
   sceptical of this because the original report that led to this patch reads:
   https://phabricator.endlessm.com/T15310 
   
   > We only show "English (United States)" in the first screen of the FBE on a
   > "base" image, which is our most commonly downloaded product.”
   
   That's not true any more: we show 8 locales, plus the currently-selected
   locale if it is not one of those.
   
   But anyway. It is easy enough to carry forward this specific behaviour
   change - just add a single function call.

pick d39934f8 timezone: set default 12h/24h from locale

Keep for now. Upstream this has been resolved in https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/merge_requests/55 for GNOME 46 but for now let's just keep our workaround.

pick a1051474 language: allow to specify initial languages from vendor.conf

Applied cleanly. Amended the patch to remove two unused variables, left over
from a simplification in a previous rebase. This would be interesting to send
upstream, though since there is a corresponding setting in gnome-control-center
it would actually be better as a GSetting.

pick f88cfa8e language: make sure initial language is always at the top

Applied cleanly. Doesn't seem *essential* but is a nice improvement.

pick bbee6361 driver: Inhibit the idle state

Applied cleanly. Keeping this for now but if we update to Initial Setup 45 a
better fix is present there.

pick dee629ff account-local: add toggle for passwordless accounts

Fixed conflicts from GTK 4 port & updated for GTK 4 API/.ui file syntax changes.

pick 6fc61aa7 account,password: Hide password page for passwordless account

Fixed conflicts from GTK 4 port & updated for GTK 4 API changes.

pick 76eef865 keyboard: manually pass locale to gkbd-keyboard-display

Applied without conflicts. This patch is weird: it builds a command-line as
a single string then parses it with `g_shell_parse_argv`. Why not just build an
array of strings? I think I have a patch to do this better lying around somewhere
so I will upstream that instead later.

pick 51921a3d timezone: Hide when automatically detected

Applied without conflict.

pick b625e8d0 eos: Report metrics from parental controls page

Applied cleanly. Amended to introduce the eosmetrics-0 dependency (which would
otherwise be added later in the series by the EULA page)


Dropped
-------

drop 99274c42 copypasta code: Use icon name instead of stock icon

- Already effectively present upstream as part of GTK 4 port

drop 65a604bb Add product_serial.conf file

- We will stop displaying a Gigabyte-specific subset of the product UUID (not
  serial despite what the commit message claims)
  
drop 77bb2e93 password: Show the last character when entering the password

- This is now set in eos-theme

drop 475b5102 input-chooser: allow CcInputChooser to expand

- No longer relevant after GTK 4 port

drop a6334008 Change generated avatar for empty name

- Removed this change – I think the upstream default looks better




TODO
----

7e692863 Allow pages to specify a GtkAccelGroup
7f409293 factory test mode: implement the factory dialog

e2f1e865 page-util: Add logic to launch eos-installer
1a94089c language: Launch eos-installer on eosinstaller images

5c024d34 live-chooser: add the Live Chooser page
52826c5c pages: Don't show some pages on live sessions
9d8c30d8 summary: show different messages on live sessions

1617c1e2 endless-eula: Add endless eula page

0aca1ee0 Configuration for Transifex
a391e024 (HEAD -> T35040-rebase-onto-41.4, origin/T35040-rebase-onto-41.4) Add translation support for several new languages
