### PR TITLE
Reimplement factory dialog

### DIFF
--- a/data/20-gnome-initial-setup.rules.in
+++ b/data/20-gnome-initial-setup.rules.in
@@ -11,6 +11,7 @@ polkit.addRule(function(action, subject) {
 
     var actionMatches = (action.id.indexOf('org.freedesktop.hostname1.') === 0 ||
                          action.id === 'com.endlessm.Metrics.SetEnabled' ||
+                         action.id === 'com.endlessm.TestMode' ||
                          action.id.indexOf('org.freedesktop.NetworkManager.') === 0 ||
                          action.id.indexOf('org.freedesktop.locale1.') === 0 ||
                          action.id.indexOf('org.freedesktop.accounts.') === 0 ||

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -185,30 +185,6 @@ check_live_persistence (GisDriver *driver)
     }
 }
 
-#define EOS_IMAGE_VERSION_PATH "/sysroot"
-#define EOS_IMAGE_VERSION_ALT_PATH "/"
-
-static char *
-get_image_version (void)
-{
-  g_autoptr(GError) error_sysroot = NULL;
-  g_autoptr(GError) error_root = NULL;
-  char *image_version =
-    gis_page_util_get_image_version (EOS_IMAGE_VERSION_PATH, &error_sysroot);
-
-  if (image_version == NULL)
-    image_version =
-      gis_page_util_get_image_version (EOS_IMAGE_VERSION_ALT_PATH, &error_root);
-
-  if (image_version == NULL)
-    {
-      g_warning ("%s", error_sysroot->message);
-      g_warning ("%s", error_root->message);
-    }
-
-  return image_version;
-}
-
 static gboolean
 image_is_reformatter (const gchar *image_version)
 {
@@ -998,7 +974,7 @@ gis_driver_startup (GApplication *app)
   gtk_window_set_child (GTK_WINDOW (driver->main_window),
                         GTK_WIDGET (driver->assistant));
 
-  image_version = get_image_version ();
+  image_version = gis_page_util_get_image_version ();
   driver->product_name = get_product_from_image_version (image_version);
 
   driver->is_live_session = running_live_session ();

--- a/gnome-initial-setup/gis-factory-dialog.c
+++ b/gnome-initial-setup/gis-factory-dialog.c
@@ -1,0 +1,227 @@
+/*
+ * gis-factory-dialog.c
+ *
+ * Copyright 2017–2024 Endless OS Foundation LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+#include "gis-factory-dialog.h"
+
+#include <polkit/polkit.h>
+
+#include "gis-pkexec.h"
+#include "gis-page-util.h"
+
+struct _GisFactoryDialog
+{
+  GtkWindow parent_instance;
+
+  GtkLabel *software_version_label;
+  GtkLabel *image_version_label;
+};
+
+G_DEFINE_FINAL_TYPE (GisFactoryDialog, gis_factory_dialog, GTK_TYPE_WINDOW)
+
+enum {
+  PROP_SOFTWARE_VERSION = 1,
+  PROP_IMAGE_VERSION,
+  N_PROPS
+};
+
+static GParamSpec *properties [N_PROPS] = { NULL, };
+
+static gboolean
+system_poweroff (GError **error)
+{
+  g_autoptr(GPermission) permission = NULL;
+  g_autoptr(GDBusConnection) bus = NULL;
+
+  permission = polkit_permission_new_sync ("org.freedesktop.login1.power-off", NULL, NULL, error);
+  if (permission == NULL)
+    {
+      g_prefix_error (error, "Failed getting permission to power off: ");
+      return FALSE;
+    }
+
+  if (!g_permission_get_allowed (permission)) {
+    g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED, "Not allowed to power off");
+    return FALSE;
+  }
+
+  bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, error);
+  if (bus == NULL) {
+    g_prefix_error (error, "Failed to get system bus: ");
+    return FALSE;
+  }
+
+  g_dbus_connection_call (bus,
+                          "org.freedesktop.login1",
+                          "/org/freedesktop/login1",
+                          "org.freedesktop.login1.Manager",
+                          "PowerOff",
+                          g_variant_new ("(b)", FALSE),
+                          NULL, 0, G_MAXINT, NULL, NULL, NULL);
+
+  return TRUE;
+}
+
+static void
+show_error (GisFactoryDialog *self,
+            const GError     *error)
+{
+  GtkWidget *dialog;
+
+  dialog = gtk_message_dialog_new (GTK_WINDOW (self),
+                                   GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                   GTK_MESSAGE_ERROR,
+                                   GTK_BUTTONS_CLOSE,
+                                   "%s", error->message);
+  g_signal_connect (dialog, "response",
+                    G_CALLBACK (gtk_window_destroy),
+                    NULL);
+  gtk_window_present (GTK_WINDOW (dialog));
+}
+
+static void
+poweroff_clicked_cb (GisFactoryDialog *self,
+                     GtkButton        *button)
+{
+  g_autoptr(GError) error = NULL;
+  if (!system_poweroff (&error))
+    g_warning ("Failed to power off: %s", error->message);
+}
+
+static void
+testmode_clicked_cb (GisFactoryDialog *self,
+                     GtkButton        *button)
+{
+  g_autoptr(GError) error = NULL;
+
+  /* Test mode can only be initialized once */
+  gtk_widget_set_sensitive (GTK_WIDGET (button), FALSE);
+
+  if (gis_pkexec ("eos-test-mode", NULL, NULL, &error))
+    gtk_window_close (GTK_WINDOW (self));
+  else
+    show_error (self, error);
+}
+
+GisFactoryDialog *
+gis_factory_dialog_new (const char *software_version,
+                        const char *image_version)
+
+{
+  return g_object_new (GIS_TYPE_FACTORY_DIALOG,
+                       "software-version", software_version,
+                       "image-version", image_version,
+                       NULL);
+}
+
+static void
+gis_factory_dialog_set_property (GObject      *object,
+                                 guint         prop_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
+{
+  GisFactoryDialog *self = GIS_FACTORY_DIALOG (object);
+
+  switch (prop_id)
+    {
+    case PROP_SOFTWARE_VERSION:
+      gtk_label_set_text (self->software_version_label, g_value_get_string (value));
+      break;
+
+    case PROP_IMAGE_VERSION:
+      gtk_label_set_text (self->image_version_label, g_value_get_string (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+gis_factory_dialog_class_init (GisFactoryDialogClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/initial-setup/gis-factory-dialog.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, GisFactoryDialog, software_version_label);
+  gtk_widget_class_bind_template_child (widget_class, GisFactoryDialog, image_version_label);
+
+  gtk_widget_class_bind_template_callback (widget_class, poweroff_clicked_cb);
+  gtk_widget_class_bind_template_callback (widget_class, testmode_clicked_cb);
+
+  object_class->set_property = gis_factory_dialog_set_property;
+
+  properties [PROP_SOFTWARE_VERSION] =
+    g_param_spec_string ("software-version", NULL,
+                         "The OS version, i.e. PRETTY_NAME from os-release",
+                         "",
+                         (G_PARAM_WRITABLE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  properties [PROP_IMAGE_VERSION] =
+    g_param_spec_string ("image-version", NULL,
+                         "eos-image-version xattr from /sysroot",
+                         "",
+                         (G_PARAM_WRITABLE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, G_N_ELEMENTS (properties), properties);
+
+  gtk_widget_class_add_binding_action (widget_class, GDK_KEY_Escape, 0, "window.close", NULL);
+}
+
+static void
+gis_factory_dialog_init (GisFactoryDialog *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+}
+
+
+void
+gis_factory_dialog_show_for_widget (GtkWidget *widget)
+{
+  g_return_if_fail (widget != NULL);
+  g_return_if_fail (GTK_IS_WIDGET (widget));
+
+  GisFactoryDialog *factory_dialog = NULL;
+  g_autofree gchar *software_version = NULL;
+  g_autofree gchar *image_version = NULL;
+  g_autofree gchar *image_version_text = NULL;
+
+  software_version = g_get_os_info (G_OS_INFO_KEY_PRETTY_NAME);
+
+  image_version = gis_page_util_get_image_version ();
+  if (!image_version)
+    image_version = g_strdup (_("Unknown"));
+
+  image_version_text = g_strdup_printf (_("Image: %s"), image_version);
+
+  factory_dialog = gis_factory_dialog_new (software_version, image_version_text);
+
+  gtk_window_set_transient_for (GTK_WINDOW (factory_dialog),
+                                GTK_WINDOW (gtk_widget_get_root (widget)));
+  gtk_window_set_modal (GTK_WINDOW (factory_dialog), TRUE);
+  gtk_window_present (GTK_WINDOW (factory_dialog));
+}

--- a/gnome-initial-setup/gis-factory-dialog.gresource.xml
+++ b/gnome-initial-setup/gis-factory-dialog.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/gnome/initial-setup">
+    <file preprocess="xml-stripblanks">gis-factory-dialog.ui</file>
+  </gresource>
+</gresources>

--- a/gnome-initial-setup/gis-factory-dialog.h
+++ b/gnome-initial-setup/gis-factory-dialog.h
@@ -1,0 +1,36 @@
+/*
+ * gis-factory-dialog.c
+ *
+ * Copyright 2017–2024 Endless OS Foundation LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+#pragma once
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+#define GIS_TYPE_FACTORY_DIALOG (gis_factory_dialog_get_type())
+
+G_DECLARE_FINAL_TYPE (GisFactoryDialog, gis_factory_dialog, GIS, FACTORY_DIALOG, GtkWindow)
+
+GisFactoryDialog *gis_factory_dialog_new (const char *software_version,
+                                          const char *image_version);
+
+void              gis_factory_dialog_show_for_widget (GtkWidget *widget);
+
+G_END_DECLS

--- a/gnome-initial-setup/gis-factory-dialog.ui
+++ b/gnome-initial-setup/gis-factory-dialog.ui
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="GisFactoryDialog" parent="GtkWindow">
+    <property name="focus_widget">poweroff-button</property>
+    <property name="default_widget">poweroff-button</property>
+    <property name="title"/>
+
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <style>
+          <class name="flat"/>
+        </style>
+      </object>
+    </child>
+
+    <child>
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="orientation">vertical</property>
+        <property name="spacing">8</property>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="vexpand">true</property>
+            <property name="valign">center</property>
+            <property name="margin-start">16</property>
+            <property name="margin-end">16</property>
+            <property name="margin-top">16</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">8</property>
+            <child>
+              <object class="GtkLabel" id="software_version_label">
+                <property name="label">Endless 1.x.y</property>
+                <attributes>
+                  <attribute name="font-desc" value="default 32"/>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="image_version_label">
+                <property name="label">image version</property>
+                <attributes>
+                  <attribute name="font-desc" value="default 16"/>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="halign">end</property>
+            <property name="spacing">8</property>
+            <property name="margin-start">16</property>
+            <property name="margin-end">16</property>
+            <property name="margin-bottom">16</property>
+            <child>
+              <object class="GtkButton" id="testmode-button">
+                <child>
+                  <object class="GtkLabel" id="testmode-label">
+                    <property name="label" translatable="true">Test Mode</property>
+                    <attributes>
+                      <attribute name="font-desc" value="default 16"/>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                </child>
+                <signal name="clicked" handler="testmode_clicked_cb" object="GisFactoryDialog" swapped="yes"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="poweroff-button">
+                <child>
+                  <object class="GtkLabel" id="label1">
+                    <property name="label" translatable="true">Power Off</property>
+                    <attributes>
+                      <attribute name="font-desc" value="default 16"/>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                </child>
+                <signal name="clicked" handler="poweroff_clicked_cb" object="GisFactoryDialog" swapped="yes"/>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/gnome-initial-setup/gis-page-util.c
+++ b/gnome-initial-setup/gis-page-util.c
@@ -33,9 +33,9 @@
 
 #define EOS_IMAGE_VERSION_XATTR "user.eos-image-version"
 
-gchar *
-gis_page_util_get_image_version (const gchar *path,
-                                 GError     **error)
+static char *
+get_image_version (const char *path,
+                   GError **error)
 {
   ssize_t attrsize;
   g_autofree gchar *value = NULL;
@@ -64,4 +64,23 @@ gis_page_util_get_image_version (const gchar *path,
                    path, g_strerror (errsv));
       return NULL;
     }
+}
+
+gchar *
+gis_page_util_get_image_version (void)
+{
+  g_autoptr(GError) error_sysroot = NULL;
+  g_autoptr(GError) error_root = NULL;
+  char *image_version = get_image_version ("/sysroot", &error_sysroot);
+
+  if (image_version == NULL)
+    image_version = get_image_version ("/", &error_root);
+
+  if (image_version == NULL)
+    {
+      g_warning ("%s", error_sysroot->message);
+      g_warning ("%s", error_root->message);
+    }
+
+  return image_version;
 }

--- a/gnome-initial-setup/gis-page-util.h
+++ b/gnome-initial-setup/gis-page-util.h
@@ -28,8 +28,7 @@
 
 G_BEGIN_DECLS
 
-gchar *gis_page_util_get_image_version (const gchar *path,
-                                        GError     **error);
+gchar *gis_page_util_get_image_version (void);
 
 G_END_DECLS
 

--- a/gnome-initial-setup/meson.build
+++ b/gnome-initial-setup/meson.build
@@ -6,11 +6,18 @@ resources = gnome.compile_resources(
     c_name: 'gis_assistant'
 )
 
+resources += gnome.compile_resources(
+    'gis-factory-dialog-resources',
+    files('gis-factory-dialog.gresource.xml'),
+    c_name: 'gis_factory_dialog'
+)
+
 sources += [
     resources,
     'cc-common-language.c',
     'gnome-initial-setup.c',
     'gis-assistant.c',
+    'gis-factory-dialog.c',
     'gis-page.c',
     'gis-page-header.c',
     'gis-page-util.c',
@@ -19,6 +26,7 @@ sources += [
     'gis-keyring.c',
     'gnome-initial-setup.h',
     'gis-assistant.h',
+    'gis-factory-dialog.h',
     'gis-page.h',
     'gis-page-header.h',
     'gis-page-util.h',

--- a/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
+++ b/gnome-initial-setup/pages/keyboard/cc-input-chooser.c
@@ -428,7 +428,8 @@ get_locale_infos (CcInputChooser *chooser)
         CcInputChooserPrivate *priv = cc_input_chooser_get_instance_private (chooser);
 	const gchar *type = NULL;
 	const gchar *id = NULL;
-	gchar *lang, *country;
+	g_autofree gchar *lang = NULL;
+	g_autofree gchar *country = NULL;
 	GList *list;
 	int non_extra_layouts = 0;
 
@@ -441,7 +442,7 @@ get_locale_infos (CcInputChooser *chooser)
 	}
 
 	if (!gnome_parse_locale (priv->locale, &lang, &country, NULL, NULL))
-		goto out;
+		return;
 
 	list = gnome_xkb_info_get_layouts_for_language (priv->xkb_info, lang);
 	non_extra_layouts += add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, FALSE);
@@ -464,10 +465,6 @@ get_locale_infos (CcInputChooser *chooser)
 	list = gnome_xkb_info_get_all_layouts (priv->xkb_info);
 	add_rows_to_list (chooser, list, INPUT_SOURCE_TYPE_XKB, id, TRUE);
 	g_list_free (list);
-
-out:
-	g_free (lang);
-	g_free (country);
 }
 
 static gboolean

--- a/gnome-initial-setup/pages/language/gis-language-page.c
+++ b/gnome-initial-setup/pages/language/gis-language-page.c
@@ -33,6 +33,7 @@
 #include "language-resources.h"
 #include "gis-welcome-widget.h"
 #include "cc-language-chooser.h"
+#include "gis-factory-dialog.h"
 #include "gis-language-page.h"
 
 #include <errno.h>
@@ -290,6 +291,16 @@ language_confirmed (CcLanguageChooser *chooser,
   gis_assistant_next_page (gis_driver_get_assistant (GIS_PAGE (page)->driver));
 }
 
+static gboolean
+gis_language_page_show_factory_dialog (GtkWidget *widget,
+                                       GVariant  *args,
+                                       gpointer   user_data)
+{
+  gis_factory_dialog_show_for_widget (widget);
+
+  return TRUE;
+}
+
 static void
 gis_language_page_constructed (GObject *object)
 {
@@ -376,6 +387,16 @@ gis_language_page_init (GisLanguagePage *page)
   g_type_ensure (CC_TYPE_LANGUAGE_CHOOSER);
 
   gtk_widget_init_template (GTK_WIDGET (page));
+
+  GtkEventController *controller = gtk_shortcut_controller_new ();
+  gtk_event_controller_set_propagation_phase (controller, GTK_PHASE_CAPTURE);
+  gtk_shortcut_controller_set_scope (GTK_SHORTCUT_CONTROLLER (controller), GTK_SHORTCUT_SCOPE_MANAGED);
+
+  GtkShortcutTrigger *trigger = gtk_shortcut_trigger_parse_string ("<Ctrl>f");
+  GtkShortcutAction *action = gtk_callback_action_new (gis_language_page_show_factory_dialog, NULL, NULL);
+  GtkShortcut *shortcut = gtk_shortcut_new (trigger, action);
+  gtk_shortcut_controller_add_shortcut (GTK_SHORTCUT_CONTROLLER (controller), shortcut);
+  gtk_widget_add_controller (GTK_WIDGET (page), controller);
 }
 
 GisPage *

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,6 +5,8 @@ data/gnome-initial-setup.desktop.in.in
 gnome-initial-setup/cc-common-language.c
 gnome-initial-setup/gis-assistant.c
 gnome-initial-setup/gis-driver.c
+gnome-initial-setup/gis-factory-dialog.c
+gnome-initial-setup/gis-factory-dialog.ui
 gnome-initial-setup/gnome-initial-setup.c
 gnome-initial-setup/pages/account/gis-account-avatar-chooser.ui
 gnome-initial-setup/pages/account/gis-account-page-enterprise.c


### PR DESCRIPTION
This is spiritually a forward-port of 7e692863 and 7f409293, but is in practice almost a total rewrite:

- Port to GTK 4.
- Use GtkShortcut for keyboard shortcut, in place of removed
  GtkAccelGroup API. We cannot use gtk_widget_class_add_binding on the
  GisLanguagePageClass because we apparently need to handle the event in
  the CAPTURE phase not the BUBBLE phase if we want it to trigger when
  the Next button in the headerbar (which is outside the
  GisLanguagePage) has focus. I learned this by reading the
  implementation of mnemonics in GtkLabel and copying it here.
- Rewrite the dialog as a custom widget, which trades one kind of
  boilerplate for another.
- Use GtkWindow not GtkDialog which is deprecated in GTK 4.10. Debian
  Bookworm has 4.8 but we were not using any of the special
  functionality of GtkDialog anyway.
- Don't show ARM product ID or x86_64 (vendor-specific selection of
  bytes from) product_uuid – no longer needed.
- Use PRETTY_NAME from os-release rather than manually combining NAME
  and VERSION to create the same string.

I also cherry-picked an upstream patch to fix a crash which you hit when running the app with `$LANG` unset, and included a couple of commits that fixup previous Endless-specific changes because I couldn't resist making some simplifications as I wrote this.

![Screenshot from 2024-02-15 13-37-22](https://github.com/endlessm/gnome-initial-setup/assets/86760/f9ffca00-2eea-4ada-b616-6ed1385d0be7)


https://phabricator.endlessm.com/T35040