### PR TITLE
privacy: Add metrics toggle

### DIFF
--- a/gnome-initial-setup/pages/privacy/gis-privacy-page.ui
+++ b/gnome-initial-setup/pages/privacy/gis-privacy-page.ui
@@ -83,6 +83,38 @@
         </child>
 
         <child>
+          <object class="AdwPreferencesGroup" id="metrics_group">
+            <property name="margin-top">12</property>
+            <child>
+              <object class="AdwActionRow" id="metrics_row">
+                <property name="title" translatable="yes">Help make Endless better for everyone</property>
+                <property name="activatable-widget">metrics_switch</property>
+                <child>
+                  <object class="GtkSwitch" id="metrics_switch">
+                    <property name="valign">center</property>
+                    <property name="active">true</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="metrics_label">
+                <property name="margin-top">12</property>
+                <property name="wrap">True</property>
+                <property name="wrap-mode">word-char</property>
+                <property name="use-markup">True</property>
+                <property name="ellipsize">none</property>
+                <property name="xalign">0.0</property>
+                <property name="label" translatable="yes">Automatically save and send usage statistics and problem reports to Endless. All data is anonymous.</property>
+                <style>
+                  <class name="caption" />
+                </style>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <child>
           <object class="AdwPreferencesGroup">
             <child>
               <object class="GtkLabel" id="footer_label">


### PR DESCRIPTION
This is the spiritual successor of half of
1617c1e20c16c2dca7abd2401cf357c7d54ff389 (“endless-eula: Add endless eula page”). I believe the setting fits more naturally on the Privacy page, where it can be displayed more prominently; this will also allow more vertical space to read the EULA in the EULA page.

The manual definition of an autocleanup for GisPrivacyPage will be obsolete in GNOME 46, where I have rewritten this file to use G_DEFINE_FINAL_TYPE which includes that boilerplate.

I have kept the strings from the previous implementation. “Help make Endless better for everyone” looks a bit weird next to the location services option on this page, but I would rather keep the wording as-is and then haggle over it separately. (For upstream, it would need to be adjusted anyway to interpolate the OS vendor at runtime.)

Compared to the previous implementation, I made the proxy construction async, because it's barely harder to do that than to make it synchronously. I kept the synchronous call to SetEnabled() because that's what everything else does in the save_data hook.

There is an argument that we should instead call this from gis_privacy_page_apply(), similar to the other toggles. Either one would work, and actually I wrote that first. gis_privacy_page_apply() can also be async. But if you make it async, a spinner and cancel button are shown; but because SetEnabled() is really quick, they only flash into existence for a frame before being replaced by the next page. It looks bad.

I can't remember why we previously deferred actually changing the option to save_data, but let's just leave it there for now.

## Normal screenshot

![image](https://github.com/endlessm/gnome-initial-setup/assets/86760/c4176b25-f436-4ef4-a04a-6d67d9b29e42)

The text is obnoxiously small, right? But that is not new in this commit.

## Large text screenshot

![image](https://github.com/endlessm/gnome-initial-setup/assets/86760/412d6869-6fea-448f-a625-be7374b76914)

Ahh, so much more legible!

https://phabricator.endlessm.com/T35040