### PR TITLE
Remove top-level scrolled window

### DIFF
--- a/gnome-initial-setup/gis-assistant.c
+++ b/gnome-initial-setup/gis-assistant.c
@@ -34,12 +34,6 @@ enum {
   PROP_LAST,
 };
 
-enum {
-  PAGE_CHANGED,
-  LAST_SIGNAL
-};
-
-static guint signals[LAST_SIGNAL];
 static GParamSpec *obj_props[PROP_LAST];
 
 struct _GisAssistant
@@ -388,7 +382,6 @@ visible_child_changed (GisAssistant *assistant,
   GtkWidget *new_page = gtk_stack_get_visible_child (stack);
 
   update_current_page (assistant, GIS_PAGE (new_page));
-  g_signal_emit (assistant, signals[PAGE_CHANGED], 0);
 }
 
 void
@@ -486,22 +479,6 @@ gis_assistant_class_init (GisAssistantClass *klass)
                          "", "",
                          NULL,
                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
-
-
-  /**
-   * GisAssistant::page-changed:
-   * @assistant: the #GisAssistant
-   *
-   * The ::page-changed signal is emitted when the visible page
-   * changed.
-   */
-  signals[PAGE_CHANGED] =
-    g_signal_new ("page-changed",
-                  G_TYPE_FROM_CLASS (gobject_class),
-                  G_SIGNAL_RUN_LAST,
-                  0,
-                  NULL, NULL, NULL,
-                  G_TYPE_NONE, 0);
 
   g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
 }

--- a/gnome-initial-setup/gis-assistant.c
+++ b/gnome-initial-setup/gis-assistant.c
@@ -64,12 +64,6 @@ struct _GisAssistant
 G_DEFINE_TYPE (GisAssistant, gis_assistant, GTK_TYPE_BOX)
 
 static void
-visible_child_changed (GisAssistant *assistant)
-{
-  g_signal_emit (assistant, signals[PAGE_CHANGED], 0);
-}
-
-static void
 switch_to (GisAssistant          *assistant,
            GisPage               *page)
 {
@@ -384,15 +378,17 @@ update_current_page (GisAssistant *assistant,
 }
 
 static void
-current_page_changed (GObject    *gobject,
-                      GParamSpec *pspec,
-                      gpointer    user_data)
+visible_child_changed (GisAssistant *assistant,
+                       GParamSpec   *pspec,
+                       GtkStack     *stack)
 {
-  GisAssistant *assistant = GIS_ASSISTANT (user_data);
-  GtkStack *stack = GTK_STACK (gobject);
+  g_return_if_fail (GIS_IS_ASSISTANT (assistant));
+  g_return_if_fail (GTK_IS_STACK (stack));
+
   GtkWidget *new_page = gtk_stack_get_visible_child (stack);
 
   update_current_page (assistant, GIS_PAGE (new_page));
+  g_signal_emit (assistant, signals[PAGE_CHANGED], 0);
 }
 
 void
@@ -431,9 +427,6 @@ static void
 gis_assistant_init (GisAssistant *assistant)
 {
   gtk_widget_init_template (GTK_WIDGET (assistant));
-
-  g_signal_connect (assistant->stack, "notify::visible-child",
-                    G_CALLBACK (current_page_changed), assistant);
 
   g_signal_connect (assistant->forward, "clicked", G_CALLBACK (go_forward), assistant);
   g_signal_connect (assistant->accept, "clicked", G_CALLBACK (go_forward), assistant);

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -255,34 +255,6 @@ gis_driver_finalize (GObject *object)
 }
 
 static void
-assistant_page_changed (GtkScrolledWindow *sw)
-{
-  gtk_adjustment_set_value (gtk_scrolled_window_get_vadjustment (sw), 0);
-}
-
-static void
-prepare_main_window (GisDriver *driver)
-{
-  GtkWidget *child, *sw;
-
-  child = gtk_window_get_child (GTK_WINDOW (driver->main_window));
-  g_object_ref (child);
-  gtk_window_set_child (GTK_WINDOW (driver->main_window), NULL);
-  sw = gtk_scrolled_window_new ();
-  gtk_window_set_child (GTK_WINDOW (driver->main_window), sw);
-  gtk_scrolled_window_set_child (GTK_SCROLLED_WINDOW (sw), child);
-  g_object_unref (child);
-
-  g_signal_connect_swapped (driver->assistant,
-                            "page-changed",
-                            G_CALLBACK (assistant_page_changed),
-                            sw);
-
-  gtk_window_set_titlebar (driver->main_window,
-                           gis_assistant_get_titlebar (driver->assistant));
-}
-
-static void
 rebuild_pages (GisDriver *driver)
 {
   g_signal_emit (G_OBJECT (driver), signals[REBUILD_PAGES], 0);
@@ -868,20 +840,13 @@ recompute_small_screen (GisDriver *driver)
 static void
 update_screen_size (GisDriver *driver)
 {
-  GtkWidget *sw;
-
   recompute_small_screen (driver);
 
   if (!gtk_widget_get_realized (GTK_WIDGET (driver->main_window)))
     return;
 
-  sw = gtk_window_get_child (GTK_WINDOW (driver->main_window));
-
   if (driver->small_screen)
     {
-      gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw),
-                                      GTK_POLICY_AUTOMATIC,
-                                      GTK_POLICY_AUTOMATIC);
       gtk_window_set_default_size (driver->main_window, -1, -1);
       gtk_window_set_resizable (driver->main_window, TRUE);
       gtk_window_maximize (driver->main_window);
@@ -889,9 +854,6 @@ update_screen_size (GisDriver *driver)
     }
   else
     {
-      gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw),
-                                      GTK_POLICY_NEVER,
-                                      GTK_POLICY_NEVER);
       gtk_window_set_default_size (driver->main_window, 1024, 768);
       gtk_window_set_resizable (driver->main_window, FALSE);
       gtk_window_unmaximize (driver->main_window);
@@ -991,7 +953,9 @@ gis_driver_startup (GApplication *app)
 
   gis_driver_set_user_language (driver, setlocale (LC_MESSAGES, NULL), FALSE);
 
-  prepare_main_window (driver);
+  gtk_window_set_titlebar (driver->main_window,
+                           gis_assistant_get_titlebar (driver->assistant));
+
   rebuild_pages (driver);
 }
 

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.ui
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.ui
@@ -2,49 +2,53 @@
 <interface>
   <template class="GisTimezonePage" parent="GisPage">
     <child>
-      <object class="GtkBox" id="box">
-        <property name="orientation">vertical</property>
-        <property name="halign">center</property>
-        <property name="valign">fill</property>
+      <object class="GtkScrolledWindow" id="scrolled_window">
         <child>
-          <object class="GisPageHeader" id="header">
-            <property name="margin_top">24</property>
-            <property name="title" translatable="yes">Time Zone</property>
-            <property name="subtitle" translatable="yes">The time zone will be set automatically if your location can be found. You can also search for a city to set it yourself.</property>
-            <property name="icon_name">find-location-symbolic</property>
-            <property name="show_icon" bind-source="GisTimezonePage" bind-property="small-screen" bind-flags="invert-boolean|sync-create"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox" id="page_box">
-            <property name="margin_top">18</property>
-            <property name="valign">center</property>
+          <object class="GtkBox" id="box">
             <property name="orientation">vertical</property>
-            <property name="spacing">14</property>
+            <property name="halign">center</property>
+            <property name="valign">fill</property>
             <child>
-              <object class="GisLocationEntry" id="search_entry">
-                <property name="halign">center</property>
-                <property name="max-width-chars">55</property>
+              <object class="GisPageHeader" id="header">
+                <property name="margin_top">24</property>
+                <property name="title" translatable="yes">Time Zone</property>
+                <property name="subtitle" translatable="yes">The time zone will be set automatically if your location can be found. You can also search for a city to set it yourself.</property>
+                <property name="icon_name">find-location-symbolic</property>
+                <property name="show_icon" bind-source="GisTimezonePage" bind-property="small-screen" bind-flags="invert-boolean|sync-create"/>
               </object>
             </child>
             <child>
-              <object class="GtkFrame" id="map_frame">
-                <property name="margin_bottom">18</property>
-                <property name="hexpand">True</property>
-                <property name="label_xalign">0</property>
+              <object class="GtkBox" id="page_box">
+                <property name="margin_top">18</property>
+                <property name="valign">center</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">14</property>
                 <child>
-                  <object class="GtkOverlay" id="map_overlay">
+                  <object class="GisLocationEntry" id="search_entry">
+                    <property name="halign">center</property>
+                    <property name="max-width-chars">55</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="map_frame">
+                    <property name="margin_bottom">18</property>
+                    <property name="hexpand">True</property>
+                    <property name="label_xalign">0</property>
                     <child>
-                      <object class="CcTimezoneMap" id="map">
-                        <property name="hexpand">True</property>
-                      </object>
-                    </child>
-                    <child type="overlay">
-                      <object class="GisBubbleWidget" id="search_overlay">
-                        <property name="label" translatable="yes">Please search for a nearby city</property>
-                        <property name="icon-name">edit-find-symbolic</property>
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
+                      <object class="GtkOverlay" id="map_overlay">
+                        <child>
+                          <object class="CcTimezoneMap" id="map">
+                            <property name="hexpand">True</property>
+                          </object>
+                        </child>
+                        <child type="overlay">
+                          <object class="GisBubbleWidget" id="search_overlay">
+                            <property name="label" translatable="yes">Please search for a nearby city</property>
+                            <property name="icon-name">edit-find-symbolic</property>
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
Currently the GisAssistant widget (which forms the body of the window, excluding the title/headerbar) is wrapped in a GtkScrolledWindow to support the small-screen case. However since the GTK 4 port, all but one page has its own internal scrolled window. Add one to that one page (timezone) and remove the toplevel one.

This is a precursor to using a WebKitWebView on a EULA page, which does its own internal scrolling and interacted badly with the outermost GtkScrolledWindow. But it's also desirable cleanup that I will send upstream to myself in due course.

https://phabricator.endlessm.com/T35040