### PR TITLE
fixup! live-chooser: add the Live Chooser page

### DIFF
--- a/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
+++ b/gnome-initial-setup/pages/live-chooser/gis-live-chooser-page.c
@@ -139,7 +139,7 @@ gis_live_chooser_page_constructed (GObject *object)
 
   G_OBJECT_CLASS (gis_live_chooser_page_parent_class)->constructed (object);
 
-  gis_page_set_has_forward (GIS_PAGE (page), FALSE);
+  gis_page_set_has_forward (GIS_PAGE (page), TRUE);
 
   priv->act_client = act_user_manager_get_default ();
 


### PR DESCRIPTION
Hide the "Next" button in the Live Chooser page. It appears that the original intent in gis-live-chooser-page.c was for this this button to be hidden. However, `gis_live_chooser_page_constructed` was incorrectly setting the `has-forward` property to FALSE (its default value), instead of setting it to TRUE.

https://phabricator.endlessm.com/T35040