### PR TITLE
Readd Endless EULA page

### DIFF
--- a/gnome-initial-setup/gis-assistant.c
+++ b/gnome-initial-setup/gis-assistant.c
@@ -34,12 +34,6 @@ enum {
   PROP_LAST,
 };
 
-enum {
-  PAGE_CHANGED,
-  LAST_SIGNAL
-};
-
-static guint signals[LAST_SIGNAL];
 static GParamSpec *obj_props[PROP_LAST];
 
 struct _GisAssistant
@@ -388,7 +382,6 @@ visible_child_changed (GisAssistant *assistant,
   GtkWidget *new_page = gtk_stack_get_visible_child (stack);
 
   update_current_page (assistant, GIS_PAGE (new_page));
-  g_signal_emit (assistant, signals[PAGE_CHANGED], 0);
 }
 
 void
@@ -486,22 +479,6 @@ gis_assistant_class_init (GisAssistantClass *klass)
                          "", "",
                          NULL,
                          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
-
-
-  /**
-   * GisAssistant::page-changed:
-   * @assistant: the #GisAssistant
-   *
-   * The ::page-changed signal is emitted when the visible page
-   * changed.
-   */
-  signals[PAGE_CHANGED] =
-    g_signal_new ("page-changed",
-                  G_TYPE_FROM_CLASS (gobject_class),
-                  G_SIGNAL_RUN_LAST,
-                  0,
-                  NULL, NULL, NULL,
-                  G_TYPE_NONE, 0);
 
   g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
 }

--- a/gnome-initial-setup/gis-assistant.c
+++ b/gnome-initial-setup/gis-assistant.c
@@ -64,12 +64,6 @@ struct _GisAssistant
 G_DEFINE_TYPE (GisAssistant, gis_assistant, GTK_TYPE_BOX)
 
 static void
-visible_child_changed (GisAssistant *assistant)
-{
-  g_signal_emit (assistant, signals[PAGE_CHANGED], 0);
-}
-
-static void
 switch_to (GisAssistant          *assistant,
            GisPage               *page)
 {
@@ -384,15 +378,17 @@ update_current_page (GisAssistant *assistant,
 }
 
 static void
-current_page_changed (GObject    *gobject,
-                      GParamSpec *pspec,
-                      gpointer    user_data)
+visible_child_changed (GisAssistant *assistant,
+                       GParamSpec   *pspec,
+                       GtkStack     *stack)
 {
-  GisAssistant *assistant = GIS_ASSISTANT (user_data);
-  GtkStack *stack = GTK_STACK (gobject);
+  g_return_if_fail (GIS_IS_ASSISTANT (assistant));
+  g_return_if_fail (GTK_IS_STACK (stack));
+
   GtkWidget *new_page = gtk_stack_get_visible_child (stack);
 
   update_current_page (assistant, GIS_PAGE (new_page));
+  g_signal_emit (assistant, signals[PAGE_CHANGED], 0);
 }
 
 void
@@ -431,9 +427,6 @@ static void
 gis_assistant_init (GisAssistant *assistant)
 {
   gtk_widget_init_template (GTK_WIDGET (assistant));
-
-  g_signal_connect (assistant->stack, "notify::visible-child",
-                    G_CALLBACK (current_page_changed), assistant);
 
   g_signal_connect (assistant->forward, "clicked", G_CALLBACK (go_forward), assistant);
   g_signal_connect (assistant->accept, "clicked", G_CALLBACK (go_forward), assistant);

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -255,34 +255,6 @@ gis_driver_finalize (GObject *object)
 }
 
 static void
-assistant_page_changed (GtkScrolledWindow *sw)
-{
-  gtk_adjustment_set_value (gtk_scrolled_window_get_vadjustment (sw), 0);
-}
-
-static void
-prepare_main_window (GisDriver *driver)
-{
-  GtkWidget *child, *sw;
-
-  child = gtk_window_get_child (GTK_WINDOW (driver->main_window));
-  g_object_ref (child);
-  gtk_window_set_child (GTK_WINDOW (driver->main_window), NULL);
-  sw = gtk_scrolled_window_new ();
-  gtk_window_set_child (GTK_WINDOW (driver->main_window), sw);
-  gtk_scrolled_window_set_child (GTK_SCROLLED_WINDOW (sw), child);
-  g_object_unref (child);
-
-  g_signal_connect_swapped (driver->assistant,
-                            "page-changed",
-                            G_CALLBACK (assistant_page_changed),
-                            sw);
-
-  gtk_window_set_titlebar (driver->main_window,
-                           gis_assistant_get_titlebar (driver->assistant));
-}
-
-static void
 rebuild_pages (GisDriver *driver)
 {
   g_signal_emit (G_OBJECT (driver), signals[REBUILD_PAGES], 0);
@@ -868,20 +840,13 @@ recompute_small_screen (GisDriver *driver)
 static void
 update_screen_size (GisDriver *driver)
 {
-  GtkWidget *sw;
-
   recompute_small_screen (driver);
 
   if (!gtk_widget_get_realized (GTK_WIDGET (driver->main_window)))
     return;
 
-  sw = gtk_window_get_child (GTK_WINDOW (driver->main_window));
-
   if (driver->small_screen)
     {
-      gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw),
-                                      GTK_POLICY_AUTOMATIC,
-                                      GTK_POLICY_AUTOMATIC);
       gtk_window_set_default_size (driver->main_window, -1, -1);
       gtk_window_set_resizable (driver->main_window, TRUE);
       gtk_window_maximize (driver->main_window);
@@ -889,9 +854,6 @@ update_screen_size (GisDriver *driver)
     }
   else
     {
-      gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (sw),
-                                      GTK_POLICY_NEVER,
-                                      GTK_POLICY_NEVER);
       gtk_window_set_default_size (driver->main_window, 1024, 768);
       gtk_window_set_resizable (driver->main_window, FALSE);
       gtk_window_unmaximize (driver->main_window);
@@ -991,7 +953,9 @@ gis_driver_startup (GApplication *app)
 
   gis_driver_set_user_language (driver, setlocale (LC_MESSAGES, NULL), FALSE);
 
-  prepare_main_window (driver);
+  gtk_window_set_titlebar (driver->main_window,
+                           gis_assistant_get_titlebar (driver->assistant));
+
   rebuild_pages (driver);
 }
 

--- a/gnome-initial-setup/gnome-initial-setup.c
+++ b/gnome-initial-setup/gnome-initial-setup.c
@@ -32,6 +32,7 @@
 #include "pages/welcome/gis-welcome-page.h"
 #include "pages/language/gis-language-page.h"
 #include "pages/keyboard/gis-keyboard-page.h"
+#include "pages/endless-eula/gis-endless-eula-page.h"
 #include "pages/network/gis-network-page.h"
 #include "pages/timezone/gis-timezone-page.h"
 #include "pages/privacy/gis-privacy-page.h"
@@ -67,6 +68,7 @@ static PageData page_table[] = {
   PAGE (language, FALSE),
   PAGE (live_chooser, TRUE),
   PAGE (keyboard, FALSE),
+  PAGE (endless_eula, TRUE),
   PAGE (network,  FALSE),
   PAGE (privacy,  FALSE),
   PAGE (timezone, TRUE),

--- a/gnome-initial-setup/pages/endless-eula/endless-eula.gresource.xml
+++ b/gnome-initial-setup/pages/endless-eula/endless-eula.gresource.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/gnome/initial-setup">
+    <file preprocess="xml-stripblanks" alias="gis-endless-eula-page.ui">gis-endless-eula-page.ui</file>
+    <file preprocess="xml-stripblanks">gis-endless-eula-viewer.ui</file>
+  </gresource>
+</gresources>
+

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
@@ -1,0 +1,67 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * Copyright (C) 2014–2024 Endless OS Foundation LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ */
+
+/* Endless EULA page {{{1 */
+
+#define PAGE_ID "endless-eula"
+
+#include "config.h"
+#include "gis-endless-eula-page.h"
+#include "gis-endless-eula-viewer.h"
+
+#include "endless-eula-resources.h"
+
+#include <gio/gio.h>
+
+
+struct _GisEndlessEulaPage {
+  GisPage parent;
+};
+
+G_DEFINE_TYPE (GisEndlessEulaPage, gis_endless_eula_page, GIS_TYPE_PAGE)
+
+static void
+gis_endless_eula_page_class_init (GisEndlessEulaPageClass *klass)
+{
+  GisPageClass *page_class = GIS_PAGE_CLASS (klass);
+
+  g_type_ensure (GIS_TYPE_ENDLESS_EULA_VIEWER);
+
+  gtk_widget_class_set_template_from_resource (GTK_WIDGET_CLASS (klass), "/org/gnome/initial-setup/gis-endless-eula-page.ui");
+
+  page_class->page_id = PAGE_ID;
+}
+
+static void
+gis_endless_eula_page_init (GisEndlessEulaPage *page)
+{
+  g_resources_register (endless_eula_get_resource ());
+
+  gtk_widget_init_template (GTK_WIDGET (page));
+}
+
+GisPage *
+gis_prepare_endless_eula_page (GisDriver *driver)
+{
+  return g_object_new (GIS_TYPE_ENDLESS_EULA_PAGE,
+                       "driver", driver,
+                       NULL);
+}

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.h
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.h
@@ -1,0 +1,37 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * Copyright (C) 2014–2024 Endless Mobile, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Cosimo Cecchi <cosimo@endlessm.com>
+ *     Will Thompson <wjt@endlessos.org>
+ */
+
+#pragma once
+
+#include "gnome-initial-setup.h"
+
+G_BEGIN_DECLS
+
+#define GIS_TYPE_ENDLESS_EULA_PAGE               (gis_endless_eula_page_get_type ())
+
+G_DECLARE_FINAL_TYPE (GisEndlessEulaPage, gis_endless_eula_page, GIS, ENDLESS_EULA_PAGE, GisPage)
+
+GisPage *gis_prepare_endless_eula_page (GisDriver *driver);
+
+G_END_DECLS

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="GisEndlessEulaPage" parent="GisPage">
+    <property name="needs-accept">true</property>
+    <property name="complete">true</property>
+    <property name="title" translatable="yes">Terms of Use</property>
+    <child>
+      <object class="GtkBox" id="box">
+        <property name="orientation">vertical</property>
+        <property name="halign">fill</property>
+        <property name="valign">fill</property>
+        <child>
+          <object class="GisPageHeader" id="header">
+            <property name="margin_top">24</property>
+            <property name="title" translatable="yes">Please read the following terms of use carefully</property>
+            <property name="subtitle" translatable="yes">By clicking "Accept," you acknowledge that you have read, understood, and agree to be bound by the following terms and conditions.</property>
+            <property name="show_icon">false</property>
+          </object>
+        </child>
+        <child>
+          <object class="GisEndlessEulaViewer" id="eula_view">
+            <property name="margin_top">18</property>
+            <property name="halign">fill</property>
+            <property name="valign">fill</property>
+            <property name="vexpand">true</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-viewer.c
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-viewer.c
@@ -1,0 +1,298 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * Copyright (C) 2018–2024 Endless OS Foundation LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Damián Nohales <damian@endlessm.com>
+ *     Will Thompson <wjt@endlessos.org>
+ */
+
+#include "config.h"
+#include "gis-endless-eula-viewer.h"
+
+#include <gtk/gtk.h>
+
+struct _GisEndlessEulaViewer {
+  WebKitWebView parent;
+
+  char *terms_uri;
+};
+
+G_DEFINE_TYPE (GisEndlessEulaViewer, gis_endless_eula_viewer, WEBKIT_TYPE_WEB_VIEW);
+
+#define LICENSE_SERVICE_URI "http://localhost:3010"
+
+static void
+notify_progress_cb (GObject    *object,
+                    GParamSpec *pspec,
+                    gpointer    user_data)
+{
+  GtkWidget *progress_bar = GTK_WIDGET (user_data);
+  WebKitWebView *web_view = WEBKIT_WEB_VIEW (object);
+  gdouble progress;
+
+  progress = webkit_web_view_get_estimated_load_progress (web_view);
+
+  if (progress == 1.0)
+    gtk_widget_hide (progress_bar);
+  else
+    gtk_widget_show (progress_bar);
+
+  gtk_progress_bar_set_fraction (GTK_PROGRESS_BAR (progress_bar), progress);
+}
+
+static void
+notify_title_cb (GObject    *object,
+                 GParamSpec *pspec,
+                 gpointer    user_data)
+{
+  WebKitWebView *web_view = WEBKIT_WEB_VIEW (object);
+  GtkWindow *dialog = GTK_WINDOW (user_data);
+  const gchar *title = webkit_web_view_get_title (web_view);
+  if (title != NULL)
+    gtk_window_set_title (dialog, title);
+}
+
+static void
+show_uri_in_modal (GisEndlessEulaViewer *viewer,
+                   const gchar          *uri,
+                   const gchar          *title)
+{
+  GtkWidget *dialog;
+  GtkWidget *overlay;
+  GtkWidget *view;
+  GtkWidget *progress_bar;
+
+  dialog = gtk_dialog_new_with_buttons (title ? title : "",
+                                        GTK_WINDOW (gtk_widget_get_root (GTK_WIDGET (viewer))),
+                                        GTK_DIALOG_MODAL |
+                                        GTK_DIALOG_USE_HEADER_BAR |
+                                        GTK_DIALOG_DESTROY_WITH_PARENT,
+                                        NULL,
+                                        NULL);
+  overlay = gtk_overlay_new ();
+  gtk_box_append (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), overlay);
+
+  progress_bar = gtk_progress_bar_new ();
+  gtk_widget_add_css_class (progress_bar, "osd");
+  gtk_widget_set_halign (progress_bar, GTK_ALIGN_FILL);
+  gtk_widget_set_valign (progress_bar, GTK_ALIGN_START);
+  gtk_overlay_add_overlay (GTK_OVERLAY (overlay), progress_bar);
+
+  view = webkit_web_view_new ();
+  gtk_widget_set_size_request (view, 800, 600);
+  gtk_widget_set_hexpand (view, TRUE);
+  gtk_widget_set_vexpand (view, TRUE);
+  g_signal_connect (view, "notify::estimated-load-progress",
+                    G_CALLBACK (notify_progress_cb), progress_bar);
+  gtk_overlay_set_child (GTK_OVERLAY (overlay), view);
+
+  g_signal_connect (view, "notify::title",
+                    G_CALLBACK (notify_title_cb), dialog);
+
+  gtk_window_present (GTK_WINDOW (dialog));
+
+  webkit_web_view_load_uri (WEBKIT_WEB_VIEW (view), uri);
+}
+
+static char *
+find_terms_document_for_language (const gchar *product_name,
+                                  const gchar *language)
+{
+  const gchar * const * data_dirs;
+  gchar *path = NULL;
+  gint i;
+
+  data_dirs = g_get_system_data_dirs ();
+
+  for (i = 0; data_dirs[i] != NULL; i++)
+    {
+      path = g_build_filename (data_dirs[i],
+                               "eos-license-service",
+                               "terms",
+                               product_name,
+                               language,
+                               "Terms-of-Use.pdf",
+                               NULL);
+
+      if (g_file_test (path, G_FILE_TEST_EXISTS))
+        return path;
+
+      g_free (path);
+    }
+
+  return NULL;
+}
+
+static char *
+find_terms_document_for_languages (const gchar *product_name,
+                                   const gchar * const *languages)
+{
+  int i;
+  gchar *path = NULL;
+
+  if (product_name == NULL)
+    return NULL;
+
+  for (i = 0; languages[i] != NULL; i++)
+    {
+      path = find_terms_document_for_language (product_name, languages[i]);
+
+      if (path != NULL)
+        return path;
+    }
+
+  /* Use "C" as a fallback. */
+  return find_terms_document_for_language (product_name, "C");
+}
+
+static GFile *
+get_terms_document (void)
+{
+  GisDriver *driver;
+  g_auto(GStrv) locale_variants = NULL;
+  const gchar *product_name;
+  const gchar *language;
+  g_autofree gchar *path = NULL;
+
+  driver = GIS_DRIVER (g_application_get_default ());
+  language = gis_driver_get_user_language (driver);
+  locale_variants = g_get_locale_variants (language);
+  product_name = gis_driver_get_product_name (driver);
+
+  path = find_terms_document_for_languages (product_name, (const gchar * const *)locale_variants);
+  if (path == NULL)
+    path = find_terms_document_for_languages ("eos", (const gchar * const *)locale_variants);
+
+  if (path == NULL)
+    {
+      g_critical ("Unable to find terms and conditions PDF on the system");
+      return NULL;
+    }
+
+  return g_file_new_for_path (path);
+}
+
+static gboolean
+gis_endless_eula_viewer_decide_policy_cb (GisEndlessEulaViewer     *self,
+                                          WebKitPolicyDecision     *decision,
+                                          WebKitPolicyDecisionType  decision_type,
+                                          gpointer                  user_data)
+{
+  g_return_val_if_fail (GIS_IS_ENDLESS_EULA_VIEWER (self), FALSE);
+
+  if (decision_type != WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION)
+    return FALSE;
+
+  WebKitNavigationPolicyDecision *navigation_decision = WEBKIT_NAVIGATION_POLICY_DECISION (decision);
+  WebKitNavigationAction *action = webkit_navigation_policy_decision_get_navigation_action (navigation_decision);
+  WebKitURIRequest *request = webkit_navigation_action_get_request (action);
+  const gchar *uri = webkit_uri_request_get_uri (request);
+
+  if (g_strcmp0 (uri, self->terms_uri) == 0)
+    {
+      webkit_policy_decision_use (decision);
+      return TRUE;
+    }
+
+  webkit_policy_decision_ignore (decision);
+
+  const gchar *title = NULL;
+
+  if (g_str_has_prefix (uri, "file:"))
+    title = _("Terms of Use");
+  else if (g_str_has_prefix (uri, LICENSE_SERVICE_URI))
+    title = _("Third Party Software");
+  else
+    /* Ignore attempts to navigate to remote pages: at this point in Initial
+     * Setup the user has not had a chance to configure Wi-Fi so is almost
+     * certainly offline.
+     */
+    return TRUE;
+
+  show_uri_in_modal (self, uri, title);
+  return TRUE;
+}
+
+static gboolean
+gis_endless_eula_viewer_context_menu_cb (WebKitWebView       *self,
+                                         WebKitContextMenu   *context_menu,
+                                         WebKitHitTestResult *hit_test_result,
+                                         gpointer             user_data)
+{
+  /* Hide default context menu: all useful actions are available in the PDF.js
+   * toolbar.
+   */
+  return TRUE;
+}
+
+static void
+load_terms_view (GisEndlessEulaViewer *self)
+{
+  g_autoptr(GFile) file = NULL;
+
+  file = get_terms_document ();
+  if (file == NULL)
+    return;
+
+  g_assert (self->terms_uri == NULL);
+  self->terms_uri = g_file_get_uri (file);
+  webkit_web_view_load_uri (WEBKIT_WEB_VIEW (self), self->terms_uri);
+}
+
+static void
+gis_endless_eula_viewer_constructed (GObject *object)
+{
+  GisEndlessEulaViewer *self = GIS_ENDLESS_EULA_VIEWER (object);
+
+  G_OBJECT_CLASS (gis_endless_eula_viewer_parent_class)->constructed (object);
+
+  load_terms_view (self);
+}
+
+
+static void
+gis_endless_eula_viewer_finalize (GObject *object)
+{
+  GisEndlessEulaViewer *self = GIS_ENDLESS_EULA_VIEWER (object);
+
+  g_clear_pointer (&self->terms_uri, g_free);
+
+  G_OBJECT_CLASS (gis_endless_eula_viewer_parent_class)->finalize (object);
+}
+
+static void
+gis_endless_eula_viewer_class_init (GisEndlessEulaViewerClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  g_type_ensure (WEBKIT_TYPE_WEB_VIEW);
+
+  gtk_widget_class_set_template_from_resource (GTK_WIDGET_CLASS (klass), "/org/gnome/initial-setup/gis-endless-eula-viewer.ui");
+  gtk_widget_class_bind_template_callback (GTK_WIDGET_CLASS (klass), gis_endless_eula_viewer_decide_policy_cb);
+  gtk_widget_class_bind_template_callback (GTK_WIDGET_CLASS (klass), gis_endless_eula_viewer_context_menu_cb);
+
+  object_class->constructed = gis_endless_eula_viewer_constructed;
+  object_class->finalize = gis_endless_eula_viewer_finalize;
+}
+
+static void
+gis_endless_eula_viewer_init (GisEndlessEulaViewer *self)
+{
+  gtk_widget_init_template (GTK_WIDGET (self));
+}

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-viewer.h
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-viewer.h
@@ -1,0 +1,36 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * Copyright (C) 2018–2024 Endless Mobile, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ *
+ * Written by:
+ *     Damián Nohales <damian@endlessm.com>
+ *     Will Thompson <wjt@endlessos.org>
+ */
+
+#pragma once
+
+#include "gnome-initial-setup.h"
+#include <webkit/webkit.h>
+
+G_BEGIN_DECLS
+
+#define GIS_TYPE_ENDLESS_EULA_VIEWER (gis_endless_eula_viewer_get_type ())
+
+G_DECLARE_FINAL_TYPE (GisEndlessEulaViewer, gis_endless_eula_viewer, GIS, ENDLESS_EULA_VIEWER, WebKitWebView)
+
+G_END_DECLS

--- a/gnome-initial-setup/pages/endless-eula/gis-endless-eula-viewer.ui
+++ b/gnome-initial-setup/pages/endless-eula/gis-endless-eula-viewer.ui
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="GisEndlessEulaViewer" parent="WebKitWebView">
+    <signal name="decide-policy" handler="gis_endless_eula_viewer_decide_policy_cb"/>
+    <signal name="context-menu" handler="gis_endless_eula_viewer_context_menu_cb"/>
+  </template>
+</interface>

--- a/gnome-initial-setup/pages/endless-eula/meson.build
+++ b/gnome-initial-setup/pages/endless-eula/meson.build
@@ -1,0 +1,12 @@
+sources += gnome.compile_resources(
+    'endless-eula-resources',
+    files('endless-eula.gresource.xml'),
+    c_name: 'endless_eula'
+)
+
+sources += files(
+    'gis-endless-eula-page.h',
+    'gis-endless-eula-page.c',
+    'gis-endless-eula-viewer.h',
+    'gis-endless-eula-viewer.c',
+)

--- a/gnome-initial-setup/pages/meson.build
+++ b/gnome-initial-setup/pages/meson.build
@@ -3,6 +3,7 @@ pages = [
    'language',
    'live-chooser',
    'keyboard',
+   'endless-eula',
    'network',
    'timezone',
    'privacy',

--- a/gnome-initial-setup/pages/timezone/gis-timezone-page.ui
+++ b/gnome-initial-setup/pages/timezone/gis-timezone-page.ui
@@ -2,49 +2,53 @@
 <interface>
   <template class="GisTimezonePage" parent="GisPage">
     <child>
-      <object class="GtkBox" id="box">
-        <property name="orientation">vertical</property>
-        <property name="halign">center</property>
-        <property name="valign">fill</property>
+      <object class="GtkScrolledWindow" id="scrolled_window">
         <child>
-          <object class="GisPageHeader" id="header">
-            <property name="margin_top">24</property>
-            <property name="title" translatable="yes">Time Zone</property>
-            <property name="subtitle" translatable="yes">The time zone will be set automatically if your location can be found. You can also search for a city to set it yourself.</property>
-            <property name="icon_name">find-location-symbolic</property>
-            <property name="show_icon" bind-source="GisTimezonePage" bind-property="small-screen" bind-flags="invert-boolean|sync-create"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox" id="page_box">
-            <property name="margin_top">18</property>
-            <property name="valign">center</property>
+          <object class="GtkBox" id="box">
             <property name="orientation">vertical</property>
-            <property name="spacing">14</property>
+            <property name="halign">center</property>
+            <property name="valign">fill</property>
             <child>
-              <object class="GisLocationEntry" id="search_entry">
-                <property name="halign">center</property>
-                <property name="max-width-chars">55</property>
+              <object class="GisPageHeader" id="header">
+                <property name="margin_top">24</property>
+                <property name="title" translatable="yes">Time Zone</property>
+                <property name="subtitle" translatable="yes">The time zone will be set automatically if your location can be found. You can also search for a city to set it yourself.</property>
+                <property name="icon_name">find-location-symbolic</property>
+                <property name="show_icon" bind-source="GisTimezonePage" bind-property="small-screen" bind-flags="invert-boolean|sync-create"/>
               </object>
             </child>
             <child>
-              <object class="GtkFrame" id="map_frame">
-                <property name="margin_bottom">18</property>
-                <property name="hexpand">True</property>
-                <property name="label_xalign">0</property>
+              <object class="GtkBox" id="page_box">
+                <property name="margin_top">18</property>
+                <property name="valign">center</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">14</property>
                 <child>
-                  <object class="GtkOverlay" id="map_overlay">
+                  <object class="GisLocationEntry" id="search_entry">
+                    <property name="halign">center</property>
+                    <property name="max-width-chars">55</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="map_frame">
+                    <property name="margin_bottom">18</property>
+                    <property name="hexpand">True</property>
+                    <property name="label_xalign">0</property>
                     <child>
-                      <object class="CcTimezoneMap" id="map">
-                        <property name="hexpand">True</property>
-                      </object>
-                    </child>
-                    <child type="overlay">
-                      <object class="GisBubbleWidget" id="search_overlay">
-                        <property name="label" translatable="yes">Please search for a nearby city</property>
-                        <property name="icon-name">edit-find-symbolic</property>
-                        <property name="halign">center</property>
-                        <property name="valign">center</property>
+                      <object class="GtkOverlay" id="map_overlay">
+                        <child>
+                          <object class="CcTimezoneMap" id="map">
+                            <property name="hexpand">True</property>
+                          </object>
+                        </child>
+                        <child type="overlay">
+                          <object class="GisBubbleWidget" id="search_overlay">
+                            <property name="label" translatable="yes">Please search for a nearby city</property>
+                            <property name="icon-name">edit-find-symbolic</property>
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -18,6 +18,9 @@ gnome-initial-setup/pages/account/gis-account-page.ui
 gnome-initial-setup/pages/account/um-photo-dialog.c
 gnome-initial-setup/pages/account/um-realm-manager.c
 gnome-initial-setup/pages/account/um-utils.c
+gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.c
+gnome-initial-setup/pages/endless-eula/gis-endless-eula-page.ui
+gnome-initial-setup/pages/endless-eula/gis-endless-eula-viewer.c
 gnome-initial-setup/pages/goa/gis-goa-page.c
 gnome-initial-setup/pages/goa/gis-goa-page.ui
 gnome-initial-setup/pages/goa/gnome-initial-setup-goa-helper.c


### PR DESCRIPTION
This is a single commit stacked on top of:

- #351

https://phabricator.endlessm.com/T35040

## Spanish

![Spanish terms of use embedded in Initial Setup](https://github.com/endlessm/gnome-initial-setup/assets/86760/67c8edfd-c974-4d27-bbf5-90a3d7dff7ad)

(Ignore the lack of translations on the headers, and feast your eyes on the Spanish-language PDF.)

## English

![Screenshot from 2024-02-27 21-18-36](https://github.com/endlessm/gnome-initial-setup/assets/86760/01b070f8-a228-46f0-8b7d-c60c52695a14)

## English large text

![Screenshot from 2024-02-27 21-18-43](https://github.com/endlessm/gnome-initial-setup/assets/86760/da8191c4-7488-4ad5-8689-bc9be88e17c9)

Something is funky about the font sizes in the PDF.js toolbar. It's not very visible here but it's really obvious if you open the dropdown menu. However… it's legible, and not a problem for today.

## License list overlay (large text)

![image](https://github.com/endlessm/gnome-initial-setup/assets/86760/d6a69fee-424a-4d20-86a8-fc5f3486911d)

## EOS 5.1, for reference

![Screenshot from 2023-12-11 16-38-58](https://github.com/endlessm/gnome-initial-setup/assets/86760/0d3092be-2915-4bfb-ad08-d34250068fd9)

I think that allowing the PDF to extend to the full width of the window, and giving it more vertical height by moving the metrics toggle to the privacy page, makes a big difference in terms of legibility. I personally find it almost impossible to read the EOS 5.1 terms.

## Changes in this version of the patch

Compared to its predecessor 1617c1e20c16c2dca7abd2401cf357c7d54ff389:

- Eliminate use of Evince library to display PDFs, as it has no GTK 4
  version at present. Use WebKitGTK's built-in copy of PDF.js instead.
  This means we gain a somewhat ugly toolbar, but there's no way to
  disable it short of embedding our own PDF.js-based viewer, which is
  not worth doing. And actually it's kind of nice to get search and zoom
  for free!

- Remove metrics control – this now lives on the privacy page, which
  seems a more natural home.

- Remove reloading the EulaView when the locale changes. (The
  locale_changed hook is actually mostly useless because all pages after
  the currently-selected page are recreated from scratch when the locale
  changes.)

- As a result, GisEndlessEulaPage is now almost nothing but boilerplate
  and a template.

- Preserve the inability to browse to any page other than file:/// URIs
  (which in practice means the English-language terms of use, from other
  translations) and the license server on localhost. You might think
  this is not a reasonable restriction because there are links to other
  pages from the terms. But as explained in the comment it may actually
  be desirable because the user is offline.

