### PR TITLE
copy-worker: Ensure worker has completed before consumers

### DIFF
--- a/data/gnome-initial-setup-copy-worker.service.in
+++ b/data/gnome-initial-setup-copy-worker.service.in
@@ -1,8 +1,11 @@
 [Unit]
 Description=GNOME Initial Setup Copy Worker
 
-# Make sure we run really early
-Before=gnome-session-pre.target graphical-session-pre.target
+# Make sure we complete very early before most consumers are started.
+Before=default.target graphical-session-pre.target
+
+# Run before any systemd activated consumers.
+Before=gnome-keyring-daemon.service
 
 # Never run in GDM
 ConditionUser=!@system

--- a/data/meson.build
+++ b/data/meson.build
@@ -64,7 +64,7 @@ data_conf.set('libexecdir', libexec_dir)
 if enable_systemd
     unit_files = {
         'gnome-initial-setup-first-login.service' : [ 'gnome-session.target.wants/' ],
-        'gnome-initial-setup-copy-worker.service' : [ 'gnome-session.target.wants/' ],
+        'gnome-initial-setup-copy-worker.service' : [ 'default.target.wants/' ],
     }
 
     foreach unit, wants: unit_files


### PR DESCRIPTION
Services such as gnome-keyring-daemon that consume the files may be systemd socket or D-Bus activated. In order to ensure the generated config files are in place in time, run the worker before any known consumers are started. While here, sprinkle in some debugging messages.

Helps: https://gitlab.gnome.org/GNOME/gnome-keyring/-/issues/137

https://phabricator.endlessm.com/T23740

This is only half the solution. gdm also needs to `chown` the files earlier. I think this is fully upstreamable, but I thought it would be a good idea to QA it on Endless first. If you think otherwise, let me know.