### PR TITLE
assistant: Set "show-title-buttons" property to false

### DIFF
--- a/gnome-initial-setup/gis-assistant.ui
+++ b/gnome-initial-setup/gis-assistant.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="gtk30">
   <object class="GtkHeaderBar" id="titlebar">
+    <property name="show-title-buttons">False</property>
     <child type="title">
       <object class="GtkLabel" id="title">
         <attributes>


### PR DESCRIPTION
Title buttons shouldn't appear in Initial Setup.

Part-of: <https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/merge_requests/237>
(cherry picked from commit a918811a92faac87cdc4e3f3a40d3d50159a9fc3)

https://phabricator.endlessm.com/T35320
