### PR TITLE
factory dialog: Show machine ID

### DIFF
--- a/gnome-initial-setup/gis-factory-dialog.c
+++ b/gnome-initial-setup/gis-factory-dialog.c
@@ -82,17 +82,11 @@ static void
 show_error (GisFactoryDialog *self,
             const GError     *error)
 {
-  GtkWidget *dialog;
+  g_autoptr(GtkAlertDialog) dialog = NULL;
 
-  dialog = gtk_message_dialog_new (GTK_WINDOW (self),
-                                   GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                   GTK_MESSAGE_ERROR,
-                                   GTK_BUTTONS_CLOSE,
-                                   "%s", error->message);
-  g_signal_connect (dialog, "response",
-                    G_CALLBACK (gtk_window_destroy),
-                    NULL);
-  gtk_window_present (GTK_WINDOW (dialog));
+  dialog = gtk_alert_dialog_new (_("Failed to Enter Test Mode"));
+  gtk_alert_dialog_set_detail (dialog, error->message);
+  gtk_alert_dialog_show (dialog, GTK_WINDOW (self));
 }
 
 static void

--- a/gnome-initial-setup/gis-factory-dialog.c
+++ b/gnome-initial-setup/gis-factory-dialog.c
@@ -31,6 +31,7 @@ struct _GisFactoryDialog
 
   GtkLabel *software_version_label;
   GtkLabel *image_version_label;
+  GtkLabel *machine_id_label;
 };
 
 G_DEFINE_FINAL_TYPE (GisFactoryDialog, gis_factory_dialog, GTK_TYPE_WINDOW)
@@ -38,6 +39,7 @@ G_DEFINE_FINAL_TYPE (GisFactoryDialog, gis_factory_dialog, GTK_TYPE_WINDOW)
 enum {
   PROP_SOFTWARE_VERSION = 1,
   PROP_IMAGE_VERSION,
+  PROP_MACHINE_ID,
   N_PROPS
 };
 
@@ -113,14 +115,15 @@ testmode_clicked_cb (GisFactoryDialog *self,
     show_error (self, error);
 }
 
-GisFactoryDialog *
+static GisFactoryDialog *
 gis_factory_dialog_new (const char *software_version,
-                        const char *image_version)
-
+                        const char *image_version,
+                        const char *machine_id)
 {
   return g_object_new (GIS_TYPE_FACTORY_DIALOG,
                        "software-version", software_version,
                        "image-version", image_version,
+                       "machine-id", machine_id,
                        NULL);
 }
 
@@ -142,6 +145,10 @@ gis_factory_dialog_set_property (GObject      *object,
       gtk_label_set_text (self->image_version_label, g_value_get_string (value));
       break;
 
+    case PROP_MACHINE_ID:
+      gtk_label_set_text (self->machine_id_label, g_value_get_string (value));
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -157,6 +164,7 @@ gis_factory_dialog_class_init (GisFactoryDialogClass *klass)
 
   gtk_widget_class_bind_template_child (widget_class, GisFactoryDialog, software_version_label);
   gtk_widget_class_bind_template_child (widget_class, GisFactoryDialog, image_version_label);
+  gtk_widget_class_bind_template_child (widget_class, GisFactoryDialog, machine_id_label);
 
   gtk_widget_class_bind_template_callback (widget_class, poweroff_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, testmode_clicked_cb);
@@ -181,6 +189,16 @@ gis_factory_dialog_class_init (GisFactoryDialogClass *klass)
                           G_PARAM_EXPLICIT_NOTIFY |
                           G_PARAM_STATIC_STRINGS));
 
+  properties [PROP_MACHINE_ID] =
+    g_param_spec_string ("machine-id", NULL,
+                         "value of /etc/machine-id",
+                         "",
+                         (G_PARAM_WRITABLE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_EXPLICIT_NOTIFY |
+                          G_PARAM_STATIC_STRINGS));
+
+
   g_object_class_install_properties (object_class, G_N_ELEMENTS (properties), properties);
 
   gtk_widget_class_add_binding_action (widget_class, GDK_KEY_Escape, 0, "window.close", NULL);
@@ -202,6 +220,8 @@ gis_factory_dialog_show_for_widget (GtkWidget *widget)
   GisFactoryDialog *factory_dialog = NULL;
   g_autofree gchar *software_version = NULL;
   g_autofree gchar *image_version = NULL;
+  g_autofree gchar *machine_id = NULL;
+  g_autoptr(GError) error = NULL;
 
   software_version = g_get_os_info (G_OS_INFO_KEY_PRETTY_NAME);
 
@@ -209,7 +229,12 @@ gis_factory_dialog_show_for_widget (GtkWidget *widget)
   if (!image_version)
     image_version = g_strdup (_("Unknown"));
 
-  factory_dialog = gis_factory_dialog_new (software_version, image_version);
+  if (g_file_get_contents ("/etc/machine-id", &machine_id, NULL, &error))
+    g_strchomp (machine_id);
+  else
+    machine_id = g_steal_pointer (&error->message);
+
+  factory_dialog = gis_factory_dialog_new (software_version, image_version, machine_id);
 
   gtk_window_set_transient_for (GTK_WINDOW (factory_dialog),
                                 GTK_WINDOW (gtk_widget_get_root (widget)));

--- a/gnome-initial-setup/gis-factory-dialog.c
+++ b/gnome-initial-setup/gis-factory-dialog.c
@@ -202,7 +202,6 @@ gis_factory_dialog_show_for_widget (GtkWidget *widget)
   GisFactoryDialog *factory_dialog = NULL;
   g_autofree gchar *software_version = NULL;
   g_autofree gchar *image_version = NULL;
-  g_autofree gchar *image_version_text = NULL;
 
   software_version = g_get_os_info (G_OS_INFO_KEY_PRETTY_NAME);
 
@@ -210,9 +209,7 @@ gis_factory_dialog_show_for_widget (GtkWidget *widget)
   if (!image_version)
     image_version = g_strdup (_("Unknown"));
 
-  image_version_text = g_strdup_printf (_("Image: %s"), image_version);
-
-  factory_dialog = gis_factory_dialog_new (software_version, image_version_text);
+  factory_dialog = gis_factory_dialog_new (software_version, image_version);
 
   gtk_window_set_transient_for (GTK_WINDOW (factory_dialog),
                                 GTK_WINDOW (gtk_widget_get_root (widget)));

--- a/gnome-initial-setup/gis-factory-dialog.h
+++ b/gnome-initial-setup/gis-factory-dialog.h
@@ -28,9 +28,6 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (GisFactoryDialog, gis_factory_dialog, GIS, FACTORY_DIALOG, GtkWindow)
 
-GisFactoryDialog *gis_factory_dialog_new (const char *software_version,
-                                          const char *image_version);
-
 void              gis_factory_dialog_show_for_widget (GtkWidget *widget);
 
 G_END_DECLS

--- a/gnome-initial-setup/gis-factory-dialog.ui
+++ b/gnome-initial-setup/gis-factory-dialog.ui
@@ -19,14 +19,16 @@
         <property name="orientation">vertical</property>
         <property name="spacing">8</property>
         <child>
-          <object class="GtkBox" id="box1">
+          <object class="GtkGrid">
             <property name="vexpand">true</property>
             <property name="valign">center</property>
+            <property name="halign">center</property>
             <property name="margin-start">16</property>
             <property name="margin-end">16</property>
             <property name="margin-top">16</property>
             <property name="orientation">vertical</property>
-            <property name="spacing">8</property>
+            <property name="row-spacing">16</property>
+            <property name="column-spacing">16</property>
             <child>
               <object class="GtkLabel" id="software_version_label">
                 <property name="label">Endless 1.x.y</property>
@@ -34,15 +36,39 @@
                   <attribute name="font-desc" value="default 32"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="column-span">2</property>
+                  <property name="row">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="true">Image</property>
+                <property name="halign">end</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">1</property>
+                </layout>
               </object>
             </child>
             <child>
               <object class="GtkLabel" id="image_version_label">
-                <property name="label">image version</property>
+                <property name="label">fake-eos1.0-amd64-amd64.160101-001234.en</property>
+                <property name="hexpand">true</property>
+                <property name="halign">start</property>
                 <attributes>
                   <attribute name="font-desc" value="default 16"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">1</property>
+                </layout>
               </object>
             </child>
           </object>

--- a/gnome-initial-setup/gis-factory-dialog.ui
+++ b/gnome-initial-setup/gis-factory-dialog.ui
@@ -4,6 +4,7 @@
   <template class="GisFactoryDialog" parent="GtkWindow">
     <property name="focus_widget">poweroff-button</property>
     <property name="default_widget">poweroff-button</property>
+    <property name="resizable">false</property>
     <property name="title"/>
 
     <child type="titlebar">

--- a/gnome-initial-setup/gis-factory-dialog.ui
+++ b/gnome-initial-setup/gis-factory-dialog.ui
@@ -71,6 +71,34 @@
                 </layout>
               </object>
             </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label" translatable="true">Machine ID</property>
+                <property name="halign">end</property>
+                <style>
+                  <class name="dim-label"/>
+                </style>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">2</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="machine_id_label">
+                <property name="label">00000000000000000000000000000000</property>
+                <property name="hexpand">true</property>
+                <property name="halign">start</property>
+                <attributes>
+                  <attribute name="font-desc" value="default 16"/>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">2</property>
+                </layout>
+              </object>
+            </child>
           </object>
         </child>
         <child>


### PR DESCRIPTION
This is useful in a factory context to check that two machines have not been incorrectly cloned from a disk image that had already been booted.

I also tweaked the error dialog shown if entering test mode fails, removing a use of a deprecated function in the process.

## Before

![image](https://github.com/user-attachments/assets/6a636659-75f6-4f72-996e-a44485a24911)


### Before (large text)

![Screenshot from 2024-07-22 12-00-04](https://github.com/user-attachments/assets/98827a8b-912a-4d53-9fdb-181606b71ea0)

![Screenshot from 2024-07-22 12-00-08](https://github.com/user-attachments/assets/0e983b93-2f34-4621-a8c6-bb6be59e24ad)

## After

![image](https://github.com/user-attachments/assets/ce2d6451-26f5-4d67-adcd-1fcbb4e8a837)

## After (large text)

![Screenshot from 2024-07-22 11-59-20](https://github.com/user-attachments/assets/40d59d1c-7507-4326-b68f-2a31748bd6e8)

![image](https://github.com/user-attachments/assets/49d9c82b-089e-4d1a-92dd-1bbd1ecb5970)



https://phabricator.endlessm.com/T35570