### PR TITLE
privacy: Remove Mozilla Location Service reference

### DIFF
--- a/gnome-initial-setup/pages/privacy/gis-privacy-page.ui
+++ b/gnome-initial-setup/pages/privacy/gis-privacy-page.ui
@@ -41,7 +41,7 @@
                 <property name="use-markup">True</property>
                 <property name="ellipsize">none</property>
                 <property name="xalign">0.0</property>
-                <property name="label" translatable="yes">Allows applications to determine your geographical location. Uses the Mozilla Location Service (&lt;a href='https://location.services.mozilla.com/privacy'&gt;privacy policy&lt;/a&gt;).</property>
+                <property name="label" translatable="yes">Allows applications to determine your geographical location.</property>
                 <signal name="activate-link" handler="activate_link" object="GisPrivacyPage" swapped="no" />
                 <style>
                   <class name="caption" />


### PR DESCRIPTION
This service has been decommissioned and the privacy policy link is 404.

I have not bothered to remove all the code that handles the link click –
it's useless but harmless, and upstream it's been refactored and is used
elsewhere.

Upstream: https://gitlab.gnome.org/GNOME/gnome-initial-setup/-/issues/214

https://phabricator.endlessm.com/T35587
