### PR TITLE
privacy: Add BeaconDB privacy policy link

### DIFF
--- a/gnome-initial-setup/pages/privacy/gis-privacy-page.ui
+++ b/gnome-initial-setup/pages/privacy/gis-privacy-page.ui
@@ -42,6 +42,20 @@
                 <property name="ellipsize">none</property>
                 <property name="xalign">0.0</property>
                 <property name="label" translatable="yes">Allows applications to determine your geographical location.</property>
+                <style>
+                  <class name="caption" />
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="margin-top">12</property>
+                <property name="wrap">True</property>
+                <property name="wrap-mode">word-char</property>
+                <property name="use-markup">True</property>
+                <property name="ellipsize">none</property>
+                <property name="xalign">0.0</property>
+                <property name="label" translatable="yes">Uses BeaconDB (&lt;a href='https://beacondb.net/privacy/'&gt;privacy policy&lt;/a&gt;).</property>
                 <signal name="activate-link" handler="activate_link" object="GisPrivacyPage" swapped="no" />
                 <style>
                   <class name="caption" />


### PR DESCRIPTION
Requires a corresponding GeoClue config change to use BeaconDB.

![image](https://github.com/user-attachments/assets/f864bda0-f57d-4bc6-a156-7e23acbe27f2)

https://phabricator.endlessm.com/T35586